### PR TITLE
get MeteringPoint.readable_by? back to how it was before

### DIFF
--- a/app/authorizers/application_authorizer.rb
+++ b/app/authorizers/application_authorizer.rb
@@ -30,8 +30,8 @@ class ApplicationAuthorizer < Authority::Authorizer
 
 
   # helper method
-  def readable?(model_class, user)
-    model_class.readable_by(user)
+  def readable?(model_class, user, *args)
+    model_class.readable_by(user, *args)
       .where(model_class.table_name + '.id = ?', resource.id)
       .select('id').size == 1
   end

--- a/app/authorizers/metering_point_authorizer.rb
+++ b/app/authorizers/metering_point_authorizer.rb
@@ -5,17 +5,22 @@ class MeteringPointAuthorizer < ApplicationAuthorizer
   end
 
   def readable_by?(user, variant = nil)
+    args = [user]
     case variant
     when :meter
-      User.any_role?(user, manager: resource)
+      return User.any_role?(user, manager: resource)
     when NilClass
-      # uses scope MeteringPoint.readable_by(user)
-      readable?(MeteringPoint, user) ||
-        # TODO get this into MeteringPoint.readable_by(user)
-        (!resource.existing_group_request.nil? && user.can_update?(resource.existing_group_request.group))
+    when :no_group_inheritance
+      args << false
+    when :group_inheritance
+      args << true
     else
       raise 'wrong argument'
     end
+    # uses scope MeteringPoint.readable_by(user)
+    readable?(MeteringPoint, *args) ||
+      # TODO get this into MeteringPoint.readable_by(user)
+      (!resource.existing_group_request.nil? && user.can_update?(resource.existing_group_request.group))
   end
 
   def updatable_by?(user, options = {})

--- a/app/controllers/api/v1/aggregates.rb
+++ b/app/controllers/api/v1/aggregates.rb
@@ -27,7 +27,8 @@ module API
               error!('it is not possible to sum metering_points with differend data_source', 406)
             else
               metering_points.each do |metering_point|
-                unless metering_point.readable_by?(current_user)
+                unless metering_point.readable_by?(current_user,
+                                                   :group_inheritance)
                   error!('Forbidden', 403)
                 end
               end
@@ -70,7 +71,8 @@ module API
               error!('it is not possible to sum metering_points with differend data_source', 406)
             else
               metering_points.each do |metering_point|
-                unless metering_point.readable_by?(current_user)
+                unless metering_point.readable_by?(current_user,
+                                                  :group_inheritance)
                   error!('Forbidden', 403)
                 end
               end

--- a/app/controllers/api/v1/groups.rb
+++ b/app/controllers/api/v1/groups.rb
@@ -101,6 +101,7 @@ module API
         get ":id/metering-points" do
           group = Group.find(permitted_params[:id])
 
+          # TODO paginated_response(MeteringPoint.by_group(group).without_externals.anonymous_readable_by(cunrret_user)
           if group.readable_by?(current_user)
             paginated_response(MeteringPoint.by_group(group).without_externals.anonymous(current_user))
           else

--- a/app/controllers/api/v1/users.rb
+++ b/app/controllers/api/v1/users.rb
@@ -92,6 +92,7 @@ module API
         get ":id/metering-points" do
           user = User.find(permitted_params[:id])
           if user.readable_by?(current_user)
+            # TODO MeteringPoint.readable_by(user, true).anonymized_readable_by(current_user)
             paginated_response(user.accessible_metering_points_relation)
           else
             status 403

--- a/app/controllers/metering_points_controller.rb
+++ b/app/controllers/metering_points_controller.rb
@@ -5,7 +5,8 @@ class MeteringPointsController < ApplicationController
 
 
   def show
-    @metering_point                 = MeteringPoint.find(params[:id]).decorate
+    # the MeteringPoint.find is just to raise NotFoundError
+    @metering_point                 = (MeteringPoint.where(id: params[:id]).anonymous(current_user).first || MeteringPoint.find(params[:id])).decorate
     @members                        = @metering_point.members.registered
     @managers                       = @metering_point.managers.registered
     @devices                        = @metering_point.devices
@@ -19,7 +20,7 @@ class MeteringPointsController < ApplicationController
     Browser.modern_rules << -> b { b.firefox? && b.version.to_i >= 41 }
     browser = Browser.new(ua: request.user_agent, accept_language: request.accept_language)
 
-    authorize_action_for(@metering_point)
+    authorize_action_for(@metering_point, :group_inheritance)
   end
 
 

--- a/app/models/metering_point.rb
+++ b/app/models/metering_point.rb
@@ -74,7 +74,11 @@ class MeteringPoint < ActiveRecord::Base
     select("#{cols}, CASE WHEN id NOT IN (#{sql}) THEN 'anonymous' ELSE name END AS name")
   end
 
-  scope :readable_by, ->(user, group_check = true) do
+  scope :anonymized_readable_by, ->(user) do
+    readable_by(user, true).anonymous(user)
+  end
+
+  scope :readable_by, ->(user, group_check = false) do
     metering_point = MeteringPoint.arel_table
     sqls = []
     if group_check
@@ -107,7 +111,7 @@ class MeteringPoint < ActiveRecord::Base
         ]
     end
     # TODO remove hack to clean SQL until the Group offers a clean AREL query
-    where(sqls.map(&:to_sql).join(' OR ').sub('DISTINCT "groups".*, ', '').sub('ORDER BY created_at ASC)',')'))
+    where(sqls.map(&:to_sql).join(' OR ').sub('DISTINCT "groups".*, ', '').sub('"groups".*, ', '').sub('ORDER BY created_at ASC)',')'))
   end
 
   scope :accessible_by_user, lambda {|user|

--- a/app/views/metering_points/show.html.haml
+++ b/app/views/metering_points/show.html.haml
@@ -1,4 +1,4 @@
-- meta title: @metering_point.long_name
+- meta title: @metering_point.readable_by?(current_user) ? @metering_point.long_name : @metering_point.name
 
 
 
@@ -16,7 +16,7 @@
           %p.text-3x.mar-no= @metering_point.name + " (" + t('virtual') + ")"
         - else
           %p.text-3x.mar-no= @metering_point.name
-        %p.text-2x.mar-no.text-thin= @metering_point.address ? @metering_point.address.short_name : t('no_address')
+        %p.text-2x.mar-no.text-thin= @metering_point.address ? (@metering_point.readable_by?(current_user) ? @metering_point.address.short_name : @metering_point.name) : t('no_address')
         %ul.list-group.bg-trans
           %li.list-group-item.list-item-sm.readability{class: "fa fa-#{@metering_point.readable_icon}", 'data-title' => t('readable_by') + ': ' + t("#{@metering_point.readable}")}
           %li.list-group-item.list-item-sm.text-primary.embed{class: "fa fa-share"}
@@ -260,7 +260,7 @@
 
     .col-md-6.col-lg-6
 
-      - if user_signed_in?
+      - if @metering_point.readable_by?(current_user)
         /.col-sm-6.col-md-6.col-lg-6
         %h1.page-header.text-overflow
           %span
@@ -293,7 +293,7 @@
               - @all_comments.map(&:image).each do |image|
                 = link_to(image_tag(image.sm), image_path(image), class: 'fancy-gallery', rel: "gallery_#{@metering_point.id}") if image.present?
 
-        - if @managers.any?
+        - if @managers.any? && @metering_point.readable_by?(current_user)
           %hr
           %h1.page-header.text-overflow
             %span
@@ -309,8 +309,7 @@
 
 
 
-      / - if user_signed_in? && current_user.can_update?(@metering_point)
-
+      / - if user_signed_in? && @metering_point.readable_by?(current_user)
       /   %h1.page-header.text-overflow
       /     %span
       /       = t('data_connection')

--- a/spec/models/metering_point_spec.rb
+++ b/spec/models/metering_point_spec.rb
@@ -64,52 +64,70 @@ let(:admin) do
 
 
   it 'restricts readable_by for anonymous users' do
-    expect(MeteringPoint.readable_by(nil)).to match_array [butenland]
+    expect(MeteringPoint.readable_by(nil)).to match_array []
+    expect(MeteringPoint.readable_by(nil, :group_inheritance)).to match_array [butenland]
     urban.update!(readable: 'world')
     [:members, :friends, :community].each do |readable|
       karin.update!(readable: readable)
-      expect(MeteringPoint.readable_by(nil)).to match_array [urban, butenland]
+      expect(MeteringPoint.readable_by(nil)).to match_array [urban]
+      expect(MeteringPoint.readable_by(nil, :group_inheritance)).to match_array [urban, butenland]
     end
     karin.update!(readable: 'world')
-    expect(MeteringPoint.readable_by(nil)).to match_array [karin, urban, butenland]
+    expect(MeteringPoint.readable_by(nil)).to match_array [karin, urban]
+    expect(MeteringPoint.readable_by(nil, :group_inheritance)).to match_array [karin, urban, butenland]
   end
 
 
   it 'restricts readable_by for community users' do
     user = Fabricate(:user)
-    expect(MeteringPoint.readable_by(user)).to match_array [butenland]
+    expect(MeteringPoint.readable_by(user)).to match_array []
     urban.update!(readable: 'community')
     [:members, :friends].each do |readable|
       karin.update!(readable: readable)
-      expect(MeteringPoint.readable_by(user)).to match_array [urban, butenland]
+      expect(MeteringPoint.readable_by(user)).to match_array [urban]
+      expect(MeteringPoint.readable_by(user, :group_inheritance)).to match_array [urban, butenland]
     end
     karin.update!(readable: 'community')
-    expect(MeteringPoint.readable_by(user)).to match_array [karin, urban, butenland]
+    expect(MeteringPoint.readable_by(user)).to match_array [karin, urban]
+    expect(MeteringPoint.readable_by(user, :group_inheritance)).to match_array [karin, urban, butenland]
   end
 
 
   it 'restricts readable_by for metering_point members or manager' do
-    expect(MeteringPoint.readable_by(member)).to match_array [urban, butenland]
-    expect(MeteringPoint.readable_by(manager)).to match_array [urban, butenland]
+    expect(MeteringPoint.readable_by(member)).to match_array [urban]
+    expect(MeteringPoint.readable_by(member, :group_inheritance)).to match_array [urban, butenland]
+    expect(MeteringPoint.readable_by(manager)).to match_array [urban]
+    expect(MeteringPoint.readable_by(manager, :group_inheritance)).to match_array [urban, butenland]
   end
 
 
   it 'restricts readable_by for metering_point for friends of manager' do
-    expect(MeteringPoint.readable_by(member.friends.first)).to match_array [butenland]
-    expect(MeteringPoint.readable_by(admin.friends.first)).to eq [butenland]
-    expect(MeteringPoint.readable_by(manager.friends.first)).to match_array [urban, butenland]
+    expect(MeteringPoint.readable_by(member.friends.first)).to match_array []
+    expect(MeteringPoint.readable_by(member.friends.first, :group_inheritance)).to match_array [butenland]
+    expect(MeteringPoint.readable_by(admin.friends.first)).to eq []
+    expect(MeteringPoint.readable_by(admin.friends.first, :group_inheritance)).to eq [butenland]
+    expect(MeteringPoint.readable_by(manager.friends.first)).to match_array [urban]
+    expect(MeteringPoint.readable_by(manager.friends.first, :group_inheritance)).to match_array [urban, butenland]
     urban.update! readable: :members
-    expect(MeteringPoint.readable_by(manager.friends.first)).to eq [butenland]
-    expect(MeteringPoint.readable_by(member.friends.first)).to eq [butenland]
-    expect(MeteringPoint.readable_by(admin.friends.first)).to eq [butenland]
+    expect(MeteringPoint.readable_by(manager.friends.first)).to eq []
+    expect(MeteringPoint.readable_by(manager.friends.first, :group_inheritance)).to eq [butenland]
+    expect(MeteringPoint.readable_by(member.friends.first)).to eq []
+    expect(MeteringPoint.readable_by(member.friends.first, :group_inheritance)).to eq [butenland]
+    expect(MeteringPoint.readable_by(admin.friends.first)).to eq []
+    expect(MeteringPoint.readable_by(admin.friends.first, :group_inheritance)).to eq [butenland]
   end
 
 
   it 'restricts readable_by for metering_point belonging to readable group' do
-    expect(MeteringPoint.readable_by(member.friends.first)).to match_array [butenland]
-    expect(MeteringPoint.readable_by(admin.friends.first)).to eq [butenland]
-    expect(MeteringPoint.readable_by(manager.friends.first)).to match_array [urban, butenland]
-    expect(MeteringPoint.readable_by(nil)).to match_array [butenland]
+    expect(MeteringPoint.readable_by(member.friends.first)).to match_array []
+    expect(MeteringPoint.readable_by(member.friends.first, :group_inheritance)).to match_array [butenland]
+    expect(MeteringPoint.readable_by(admin.friends.first)).to eq []
+    
+    expect(MeteringPoint.readable_by(admin.friends.first, :group_inheritance)).to eq [butenland]
+    expect(MeteringPoint.readable_by(manager.friends.first)).to match_array [urban]
+    expect(MeteringPoint.readable_by(manager.friends.first, :group_inheritance)).to match_array [urban, butenland]
+    expect(MeteringPoint.readable_by(nil)).to match_array []
+    expect(MeteringPoint.readable_by(nil, :group_inheritance)).to match_array [butenland]
 
     butenland.group.update! readable: :members
     expect(MeteringPoint.readable_by(manager.friends.first)).to eq [urban]


### PR DESCRIPTION
there are two places where the MeteringPoint.readable_by? looks at the
underlying group: app/controllers/api/v1/aggregates.rb and
app/controllers/metering_points.rb#show

fixes #284
