### PR TITLE
implement the new aggregation endpoints

### DIFF
--- a/app/controllers/api/v1/aggregates.rb
+++ b/app/controllers/api/v1/aggregates.rb
@@ -22,7 +22,7 @@ module API
           if current_user.nil? && !(register.group && register.group.readable_by_world?) && !register.readable_by_world?
             raise Buzzn::PermissionDenied
           end
-          data_result = Buzzn::Application.config.current_power.for_register(register, permitted_params[:timestamp])
+          data_result = Buzzn::Application.config.current_power.for_register(register)#, permitted_params[:timestamp])
           unless permitted_params[:timestamp]
             # cache-control headers
             etag(data_result.timestamp.to_s + data_result.value.to_s)

--- a/app/controllers/api/v1/defaults.rb
+++ b/app/controllers/api/v1/defaults.rb
@@ -146,9 +146,9 @@ module API
 
         rescue_from ArgumentError do |e|
           errors = ErrorResponse.new(422, { Grape::Http::Headers::CONTENT_TYPE => content_type })
-          if Rails.env.development?
-            puts e.message
-            puts e.backtrace.join("\n\t")
+          if Rails.env.development? ||  Rails.env.test?
+            warn e.message
+            warn e.backtrace.join("\n\t")
           end
           errors.add_general('Argument Error', e.message)
           errors.finish

--- a/app/controllers/api/v1/profiles.rb
+++ b/app/controllers/api/v1/profiles.rb
@@ -1,3 +1,4 @@
+require 'profile_resource'
 module API
   module V1
     class Profiles < Grape::API

--- a/app/controllers/api/v1/registers.rb
+++ b/app/controllers/api/v1/registers.rb
@@ -4,6 +4,43 @@ module API
       include API::V1::Defaults
       resource :registers do
 
+        params do
+          requires :id, type: String
+          requires :duration, type: String, values: %w(year month day hour)
+          optional :timestamp, type: Time
+        end
+        oauth2 false
+        get ":id/charts" do
+          register = Register::Base.guarded_retrieve(current_user, permitted_params)
+          interval = Buzzn::Interval.create(params[:duration], params[:timestamp])
+          result = Buzzn::Application.config.charts.for_register(register, interval)
+
+          # cache-control headers
+          etag(Digest::SHA256.base64digest(result.to_json))
+          expires((result.expires_at - Time.current.to_f).to_i,
+                  current_user ? :private : :public)
+          last_modified(Time.at(result.last_timestamp)) 
+
+          result
+        end
+
+        params do
+          requires :id, type: String
+        end
+        oauth2 false
+        get ":id/ticker" do
+          register = Register::BaseResource.retrieve(current_user,
+                                                     permitted_params)
+          result = Buzzn::Application.config.current_power.for_register(register)
+
+          # cache-control headers
+          etag(Digest::SHA256.base64digest(result.to_json))
+          last_modified(Time.at(result.timestamp))
+          expires((result.expires_at - Time.current.to_f).to_i,
+                  current_user ? :private : :public)
+
+          result
+        end
 
         namespace :real do
           ["input", "output"].each do |mode|

--- a/lib/buzzn/base_resource.rb
+++ b/lib/buzzn/base_resource.rb
@@ -75,7 +75,7 @@ module Buzzn
         @abstract = true
       end
 
-      # crud API
+      # the 'R' from the crud API
 
       def find_resource_class(clazz)
         if clazz == model || clazz == Object

--- a/lib/buzzn/charts.rb
+++ b/lib/buzzn/charts.rb
@@ -9,7 +9,27 @@ module Buzzn
     def for_register(register, interval)
       raise ArgumentError.new("not a #{Register::Base}") unless register.is_a?(Register::Base)
       raise ArgumentError.new("not a #{Buzzn::Interval}") unless interval.is_a?(Buzzn::Interval)
-      @registry.get(register.data_source).aggregated(register, register.direction, interval)
+      result = @registry.get(register.data_source).aggregated(register, register.direction, interval)
+      finalize(result, interval)
+    end
+
+    def finalize(result, interval)
+      ttl = if interval.to < Time.current.to_f
+              1.day
+            else
+              case interval.duration
+              when :hour
+                15.seconds
+              when :day
+                15.minutes
+              when :month
+                1.hour
+              when :year
+                1.day
+              end
+            end
+      result.expires_at = Time.current.to_f + ttl
+      result.freeze
     end
 
     def for_group(group, interval)
@@ -21,8 +41,7 @@ module Buzzn
         result.add_all(data_source.aggregated(group, :in, interval), interval.duration)
         result.add_all(data_source.aggregated(group, :out, interval), interval.duration)
       end
-      result.freeze
-      result
+      finalize(result, interval)
     end
 
   end

--- a/lib/buzzn/check_types_data_source.rb
+++ b/lib/buzzn/check_types_data_source.rb
@@ -7,15 +7,15 @@ module Buzzn
     def collection(resource, mode)
       raise 'mode is nil' unless mode
       raise 'resource is nil' unless resource
-      raise 'resource not a Group::Base or Register' if !resource.is_a?(Group::Base) && !resource.is_a?(Register)
-      raise 'Register needs to be virtual' if resource.is_a?(Register) && resource.virtual == false
+      raise 'resource not a Group::MinimalBaseResource or Register::BaseResource' if !resource.is_a?(Group::Base) && !resource.is_a?(Register::Base) && !resource.is_a?(Group::MinimalBaseResource) && !resource.is_a?(Register::BaseResource)
+      raise 'Register must not be virtual' if resource.is_a?(Register::Virtual)
       nil
     end
 
     def single_aggregated(resource, mode)
       raise 'mode is nil' unless mode
       raise 'resource is nil' unless resource
-      raise 'resource not a Group::Base or Register' if !resource.is_a?(Group::Base) && !resource.is_a?(Register)
+      raise 'resource not a Group::MinimalBaseResource or Register::BaseResource' if !resource.is_a?(Group::Base) && !resource.is_a?(Register::Base) && !resource.is_a?(Group::MinimalBaseResource) && !resource.is_a?(Register::BaseResource)
       nil
     end
 
@@ -23,8 +23,8 @@ module Buzzn
       raise 'interval is nil' unless interval
       raise 'mode is nil' unless mode
       raise 'resource is nil' unless resource
-      raise 'resource not a Group::Base or Register' if !resource.is_a?(Group::Base) && !resource.is_a?(Register)
-      raise 'Register must not be virtual' if resource.is_a?(Register) && resource.virtual == false
+      raise 'resource not a Group::MinimalBaseResource or Register::BaseResource' if !resource.is_a?(Group::Base) && !resource.is_a?(Register::Base) && !resource.is_a?(Group::MinimalBaseResource) && !resource.is_a?(Register::BaseResource)
+      raise 'Register must not be virtual' if resource.is_a?(Register::Virtual)
       nil
     end
   end

--- a/lib/buzzn/data_result.rb
+++ b/lib/buzzn/data_result.rb
@@ -34,8 +34,13 @@ module Buzzn
       super.merge(resource_id: @resource_id, mode: @mode)
     end
 
+    def freeze
+      @json = to_json
+      super
+    end
+
     def to_json(*args)
-      @json || "{\"timestamp\":\"#{@timestamp}\",\"value\":#{@value},\"resource_id\":\"#{@resource_id}\",\"mode\":\"#{@mode}\",\"expires_at\":#{expires_at}}"
+      @json || "{\"timestamp\":#{@timestamp},\"value\":#{@value},\"resource_id\":\"#{@resource_id}\",\"mode\":\"#{@mode}\",\"expires_at\":#{expires_at}}"
     end
   end
 end

--- a/lib/buzzn/data_result_array.rb
+++ b/lib/buzzn/data_result_array.rb
@@ -23,7 +23,10 @@ module Buzzn
     end
 
     def +(other)
-      other.each { |i| push(i) }
+      if other && !other.empty?
+        other.each { |i| push(i) }
+        @expires_at = [@expires_at.to_f, other.expires_at.to_f].max
+      end
       self
     end
 
@@ -34,5 +37,10 @@ module Buzzn
     def to_json(*args)
       @json || "{\"expires_at\":#{expires_at},\"array\":#{super}}"
     end
+
+    def inspect
+      "#<#{self.class}\:#{object_id.to_s(16)} @expires_at: #{@expires_at}, #{super.inspect}>"
+    end
+    alias :to_s :inspect
   end
 end

--- a/lib/buzzn/data_result_set.rb
+++ b/lib/buzzn/data_result_set.rb
@@ -1,6 +1,7 @@
 module Buzzn
   class DataResultSet
     attr_reader :resource_id, :in, :out, :units
+    attr_accessor :expires_at
 
     class << self
       private :new
@@ -94,8 +95,11 @@ module Buzzn
     end
 
     def freeze
+      @json = to_json
+      super
       @in.freeze
       @out.freeze
+      self
     end
 
     def to_hash
@@ -103,6 +107,10 @@ module Buzzn
         resource_id: @resource_id,
         in: @in.collect { |i| i.to_hash },
         out: @out.collect { |i| i.to_hash } }
+    end
+
+    def to_json(*args)
+      @json || "{\"units\":\"#{@units}\",\"resource_id\":\"#{@resource_id}\",\"in\":#{@in.to_json},\"out\":#{@out.to_json}}"
     end
 
     def merge_lists(target, source, duration, operator)
@@ -151,6 +159,12 @@ module Buzzn
         end
       end
       return -1
+    end
+    private :find_matching_timestamp
+
+    def last_timestamp
+      (@in.collect { |i| i.timestamp } +
+         @out.collect { |i| i.timestamp }).max || 0
     end
   end
 end

--- a/lib/buzzn/data_source_caching.rb
+++ b/lib/buzzn/data_source_caching.rb
@@ -23,11 +23,11 @@ module Buzzn
             _with_lock(key) do
               result = clazz.from_json(_cache_get(key))
               if result.nil? || result.expires_at < Time.current.to_f
-                @logger.error{"[buzzn.datasource_caching]<#{Thread.current.object_id}> #{key} ====> stale"}
+                @logger.error{"#{key} ====> stale"}
                 result = send("raw_#{method}".to_sym, resource, mode)
                 _cache_put(key, result.to_json)
               else
-                @logger.error{"[datasource.caching]<#{Thread.current.object_id}> #{key} ====> hit"}
+                @logger.error{"#{key} ====> hit"}
               end
               result
             end
@@ -49,7 +49,9 @@ module Buzzn
         end
 
         def _cache_key(prefix, resource, mode)
-          "#{prefix}/#{self.class.to_s.underscore}/#{resource.class.table_name}/#{resource.id}/#{mode}"
+          #TODO remove this when we are sure we have Buzzn::EntityResource
+          name = resource.class.respond_to?(:name) ?resource.class.name : resource.class.table_name
+          "#{prefix}/#{self.class.to_s.underscore}/#{name}/#{resource.id}/#{mode}"
         end
       end
     end

--- a/lib/buzzn/interval.rb
+++ b/lib/buzzn/interval.rb
@@ -6,6 +6,10 @@ module Buzzn
 
     class << self
       private :new
+
+      def create(duration, timestamp)
+        send(duration.to_sym, timestamp)
+      end
     end
 
     def initialize(from, to)
@@ -42,6 +46,10 @@ module Buzzn
       end
     end
 
+    def to_s
+      "[#{from_as_utc_time}, #{to_as_utc_time})"
+    end
+
     private
     def _year?
       timespan = self.to - self.from
@@ -76,7 +84,8 @@ module Buzzn
     class << self
       private :new
 
-      def year(timestamp = Time.current)
+      def year(timestamp = nil)
+        timestamp ||= Time.current
         if timestamp.is_a?(Time)
           new(
             timestamp.beginning_of_year.to_f,
@@ -87,7 +96,8 @@ module Buzzn
         end
       end
 
-      def month(timestamp = Time.current)
+      def month(timestamp = nil)
+        timestamp ||= Time.current
         if timestamp.is_a?(Time)
           new(
             timestamp.beginning_of_month.to_f,
@@ -98,7 +108,8 @@ module Buzzn
         end
       end
 
-      def day(timestamp = Time.current)
+      def day(timestamp = nil)
+        timestamp ||= Time.current
         if timestamp.is_a?(Time)
           new(
             timestamp.beginning_of_day.to_f,
@@ -109,7 +120,8 @@ module Buzzn
         end
       end
 
-      def hour(timestamp = Time.current)
+      def hour(timestamp = nil)
+        timestamp ||= Time.current
         if timestamp.is_a?(Time)
           new(
             timestamp.beginning_of_hour.to_f,

--- a/lib/buzzn/logger.rb
+++ b/lib/buzzn/logger.rb
@@ -16,7 +16,7 @@ module Buzzn
     end
 
     def initialize(clazz, root)
-      @category = clazz.to_s.underscore.sub('/', '.')
+      @category = clazz.to_s.underscore.gsub('/', '.')
       @root = root
     end
 

--- a/spec/lib/buzzn/charts_spec.rb
+++ b/spec/lib/buzzn/charts_spec.rb
@@ -4,7 +4,10 @@ describe Buzzn::Charts do
   class DummyDataSource < Buzzn::DataSource
     NAME = :dummy
     def method_missing(method, *args)
-      [method] + args
+      # this is just an array with an extra expires_at field
+      result = [method] + args
+      def result.expires_at=(a);end
+      result
     end
     def aggregated(resource, mode, interval)
       method_missing(:aggregated, resource, mode, interval) unless resource.is_a? Group::Base

--- a/spec/lib/buzzn/standard_profile/data_source_spec.rb
+++ b/spec/lib/buzzn/standard_profile/data_source_spec.rb
@@ -37,7 +37,7 @@ describe Buzzn::StandardProfile::DataSource do
 
   describe 'single_aggregated' do
 
-    [:slp, :sep_bhkw, :sep_pv].each do |type|
+    [Reading::SLP, Reading::SEP_BHKW, Reading::SEP_PV].each do |type|
 
       it "#{type} register" do
         register = send("#{type}_register".to_sym)
@@ -53,7 +53,7 @@ describe Buzzn::StandardProfile::DataSource do
 
         Timecop.freeze(utc.local(2015,4,6))
         begin
-          direction = type == :slp ? :in : :out
+          direction = type == Reading::SLP ? :in : :out
           single_aggregated = data_source.single_aggregated(register, direction)
           expect(single_aggregated.mode).to eq direction
           expect(single_aggregated.resource_id).to eq register.id
@@ -144,7 +144,7 @@ describe Buzzn::StandardProfile::DataSource do
             if direction == :out
               expect(sum_values).to eq (1900000 + 110000)
             else
-              expect(sum_values).to eq (collection.count * 930000)
+              expect(sum_values).to eq (collection.count * 930000.0)
             end
           end
         ensure

--- a/spec/requests/api/v1/group_aggregation_spec.rb
+++ b/spec/requests/api/v1/group_aggregation_spec.rb
@@ -1,0 +1,532 @@
+describe "/groups" do
+
+  let(:discovergy_meter) do
+    meter = Fabricate(:easymeter_60139082) # in_out meter
+    meter.registers.each { |r| r.update(readable: :world) }
+    # TODO what to do with the in-out fact ?
+    Fabricate(:discovergy_broker, resource: meter, external_id: "EASYMETER_60139082", mode: :in_out)
+    meter
+  end
+
+  let(:profile_meter) do
+    meter = Fabricate(:input_meter)
+    Fabricate(:output_register, meter: meter)
+    meter.registers.each { |r| r.update(readable: :world) }
+    meter
+  end
+
+  let(:group) do
+    group = Fabricate(:tribe)
+    group.registers += discovergy_meter.registers
+    group
+  end
+
+  let(:profile_group) do
+    group = Fabricate(:tribe)
+    group.registers += profile_meter.registers.reload
+    group
+  end
+
+  let(:input_register) { discovergy_meter.input_register }
+
+  let(:output_register) { discovergy_meter.output_register }
+
+  let(:slp_register) { profile_meter.input_register }
+
+  let(:sep_register) { profile_meter.output_register }
+
+  let(:token) { Fabricate(:full_access_token_as_admin) }
+
+  let(:time) { Time.find_zone('Berlin').local(2016, 2, 1, 1, 30, 1) }
+
+  let(:denied_json) do
+    {
+      "errors" => [{"title"=>"Permission Denied",
+                    "detail"=>"retrieve Group::Base: permission denied for User: --anonymous--"}]
+    }
+  end
+  let(:not_found_json) do
+    {
+      "errors" => [{"title"=>"Permission Denied",
+                    "detail"=>"Group::Base: bla-bla-bla not found"}]
+    }
+  end
+
+  context '/bubbles' do
+
+    let(:discovergy_json) do
+      # this is not real world and a bit quirk do to the VCR setup
+      # but shows the generic format and functionality
+      {
+        "expires_at" => 1454286616.0,
+        "array" => [
+          {"timestamp" => 1467446702.088, "value" => 1100640.0,
+           "resource_id" => output_register.id, "mode" => "in"},
+          {"timestamp" => 1467446702.088, "value" => 0.0,
+           "resource_id" => input_register.id, "mode" => "in"},
+          {"timestamp" => 1467446703.088, "value" => 1300640.0,
+           "resource_id" => output_register.id, "mode" => "out"},
+          {"timestamp" => 1467446702.088, "value" => 1200640.0,
+           "resource_id" => input_register.id, "mode" => "out"}
+        ]
+      }
+    end
+
+    let(:second_discovergy_json) do
+      # this is not real world and a bit quirk do to the VCR setup
+      # but shows the generic format and functionality
+      {
+        "array" => [
+          {"timestamp" => 1467446702.188, "value" => 2100640.0,
+           "resource_id" => output_register.id, "mode" => "in"},
+          {"timestamp" => 1467446702.188, "value" => 0.0,
+           "resource_id" => input_register.id, "mode" => "in"},
+          {"timestamp" => 1467446702.188, "value" => 2200640.0,
+           "resource_id" => output_register.id, "mode" => "out"},
+          {"timestamp" => 1467446703.188, "value" => 2300640.0,
+           "resource_id" => input_register.id, "mode" => "out"}
+        ],
+        "expires_at" => 1454286641.0
+      }
+    end
+
+    let(:profile_json) do
+      { "array" => [{"timestamp" => 1454287500.0, "value" => 930007.0,
+                     "resource_id" => slp_register.id, "mode" => "in"},
+                    {"timestamp" => 1454286660.0, "value" => 123006.0,
+                     "resource_id" => sep_register.id, "mode" => "out"}],
+        # last_readings + 15.minutes - 1 (as current time is 01:30:01)
+        "expires_at"=> (time + 15.minutes - 1).to_f }
+    end
+
+    it 'fails without permissions' do
+      group.update(readable: :members)
+      GET "/api/v1/groups/#{group.id}/bubbles"
+      expect(response).to have_http_status(403)
+      expect(json).to eq denied_json
+    end
+
+    it 'fails with not found' do
+      GET "/api/v1/groups/bla-bla-bla/bubbles"
+      expect(response).to have_http_status(404)
+      expect(json).to eq not_found_json
+    end
+
+    it 'discovergy' do
+      VCR.use_cassette("request/api/v1/discovergy") do
+
+        time = Time.find_zone('Berlin').local(2016, 2, 1, 1, 30, 1)
+        begin
+          Timecop.freeze(time)
+
+          GET "/api/v1/groups/#{group.id}/bubbles"
+
+          expect(response).to have_http_status(200)
+          expect(json).to eq(discovergy_json)
+          expect(response.headers['Expires']).not_to be_nil
+          expect(response.headers['Cache-Control']).to eq "public, max-age=15"
+          expect(response.headers['ETag']).not_to be_nil
+          expect(response.headers['Last-Modified']).not_to be_nil
+
+          GET "/api/v1/groups/#{group.id}/bubbles", {}, token
+
+          expect(response).to have_http_status(200)
+          expect(json).to eq(discovergy_json)
+          expect(expires = response.headers['Expires']).not_to be_nil
+          expect(response.headers['Cache-Control']).to eq "private, max-age=15"
+          expect(etag = response.headers['ETag']).not_to be_nil
+          expect(modified = response.headers['Last-Modified']).not_to be_nil
+
+          # cache hit
+          Timecop.freeze(time + 5)
+          GET "/api/v1/groups/#{group.id}/bubbles", {}, token
+
+          expect(response).to have_http_status(200)
+          expect(json).to eq(discovergy_json)          
+          expect(response.headers['Expires']).to eq expires
+          expect(response.headers['ETag']).to eq etag
+          expect(response.headers['Last-Modified']).to eq modified
+
+          # no cache hit
+          Timecop.freeze(time + 25)
+          GET "/api/v1/groups/#{group.id}/bubbles"
+
+          expect(response).to have_http_status(200)
+          expect(json).to eq(second_discovergy_json)
+          expect(response.headers['Expires']).not_to eq expires
+          expect(response.headers['ETag']).not_to eq etag
+          expect(response.headers['Last-Modified']).not_to eq modified    
+        ensure
+          Timecop.return
+        end
+      end
+    end
+
+    it 'standard profile' do
+      timestamp = Time.find_zone('Berlin').local(2016, 2, 1)
+      40.times do |i|
+        Fabricate(:reading,
+                  source: Reading::SLP,
+                  timestamp: timestamp,
+                  power_milliwatt: 930000 + i,
+                  reason: Reading::REGULAR_READING,
+                  quality: Reading::READ_OUT
+                 )
+        Fabricate(:reading,
+                  source: Reading::SEP_BHKW,
+                  # distort the timestamp a bit
+                  timestamp: timestamp + 1.minute,
+                  power_milliwatt: 123000 + i,
+                  reason: Reading::REGULAR_READING,
+                  quality: Reading::READ_OUT
+                 )
+        timestamp += 15.minutes
+      end
+
+      begin
+        Timecop.freeze(time)
+
+        GET "/api/v1/groups/#{profile_group.id}/bubbles"
+
+        expect(response).to have_http_status(200)
+        expect(json).to eq(profile_json)
+        expect(response.headers['Expires']).not_to be_nil
+        # - 1 minute see 'time' and when readings were created
+        expect(response.headers['Cache-Control']).to eq "public, max-age=899"
+        expect(response.headers['ETag']).not_to be_nil
+        expect(response.headers['Last-Modified']).not_to be_nil
+
+        GET "/api/v1/groups/#{profile_group.id}/bubbles", {}, token
+
+        expect(response).to have_http_status(200)
+        expect(json).to eq(profile_json)
+        expect(response.headers['Expires']).not_to be_nil
+        # - 1 minute see 'time' and when readings were created
+        expect(response.headers['Cache-Control']).to eq "private, max-age=899"
+        expect(response.headers['ETag']).not_to be_nil
+        expect(response.headers['Last-Modified']).not_to be_nil
+      ensure
+        Timecop.return
+      end
+    end
+  end
+
+  context '/charts' do
+    let(:hour_json) do
+      { "units" => "milliwatt",
+        "resource_id" => group.id,
+        "in"=>[{"timestamp"=>1467446702.088, "value"=>3302020.0},
+               {"timestamp"=>1467446702.288, "value"=>1100740.0}],
+        "out"=>[{"timestamp"=>1467446702.088, "value"=>0.0},
+                {"timestamp"=>1467446702.288, "value"=>0.0}]
+      }
+    end
+
+    let(:day_json) do
+      { "units" => "milliwatt",
+        "resource_id" => group.id,
+        "in"=>[{"timestamp"=>1483138800.0, "value"=>882855.2836},
+               {"timestamp"=>1483139700.0, "value"=>305943.0632},
+               {"timestamp"=>1483140600.0, "value"=>896316.3292},
+               {"timestamp"=>1483141500.0, "value"=>894245.9292}],
+        "out"=>[{"timestamp"=>1483225200.0, "value"=>1023712.5864},
+                {"timestamp"=>1483226100.0, "value"=>1080270.0296},
+                {"timestamp"=>1483227000.0, "value"=>1228515.572},
+                {"timestamp"=>1483227900.0, "value"=>1076732.8432}]
+      }
+    end
+    let(:yesterday_json) do
+      { "units"=>"milliwatt",
+        "resource_id" => group.id,
+        "in"=>[{"timestamp"=>1483138800.0, "value"=>882855.2836},
+               {"timestamp"=>1483139700.0, "value"=>305943.0632},
+               {"timestamp"=>1483140600.0, "value"=>896316.3292},
+               {"timestamp"=>1483141500.0, "value"=>894245.9292}],
+        "out"=>[{"timestamp"=>1483225200.0, "value"=>1023712.5864},
+                {"timestamp"=>1483226100.0, "value"=>1080270.0296},
+                {"timestamp"=>1483227000.0, "value"=>1228515.572},
+                {"timestamp"=>1483227900.0, "value"=>1076732.8432}]
+      }
+    end
+    let(:month_json) do
+      { "units" => "milliwatt_hour",
+        "resource_id" => group.id,
+        "in"=>[{"timestamp"=>1483225200.0, "value"=>34619930.5348},
+               {"timestamp"=>1483311600.0, "value"=>52223658.0036}],
+        "out"=>[{"timestamp"=>1483225200.0, "value"=>34619930.5348},
+                {"timestamp"=>1483311600.0, "value"=>52223658.0036}]
+      }
+    end
+    let(:year_json) do
+      { "units" => "milliwatt_hour",
+        "resource_id" => group.id,
+        "in"=>[{"timestamp"=>1483225200.0, "value"=>63591795.5281},
+               {"timestamp"=>1483311600.0, "value"=>21232911.5229}],
+        "out"=>[{"timestamp"=>1483225200.0, "value"=>63591795.5281},
+                {"timestamp"=>1483311600.0, "value"=>21232911.5229}]
+      }
+    end
+    let(:missing_json) do
+      {
+        "errors" => [{"parameter" => "duration",
+                      "source" => {
+                        "pointer" => "/data/attributes/duration"},
+                      "title" => "Invalid Attribute",
+                      "detail" => "duration is missing"}]
+      }
+    end
+    let(:invalid_json) do
+      {
+        "errors" => [{"parameter" => "duration",
+                      "source" => {
+                        "pointer" => "/data/attributes/duration"},
+                      "title" => "Invalid Attribute",
+                      "detail" => "duration does not have a valid value"}]
+      }
+    end
+
+    it 'fails on missing duration parameter' do
+      GET "/api/v1/groups/#{group.id}/charts", {}, token
+      expect(response).to have_http_status(422)
+      expect(json).to eq missing_json
+    end
+    
+    it 'fails on wrong duration parameter' do
+      GET "/api/v1/groups/#{group.id}/charts", { duration: :century }
+      expect(response).to have_http_status(422)
+      expect(json).to eq invalid_json
+    end
+
+    it 'fails without permissions' do
+      group.update(readable: :members)
+      GET "/api/v1/groups/#{group.id}/charts", { duration: :day }
+      expect(response).to have_http_status(403)
+      expect(json).to eq denied_json
+    end
+
+    it 'fails with not found' do
+      GET "/api/v1/groups/bla-bla-bla/charts", { duration: :year }
+      expect(response).to have_http_status(404)
+      expect(json).to eq not_found_json
+    end
+
+    it 'discovergy' do
+      VCR.use_cassette("request/api/v1/discovergy") do
+        
+        begin
+          Timecop.freeze(time)
+
+          GET "/api/v1/groups/#{group.id}/charts", { duration: :hour }, token
+          expect(response).to have_http_status(200)
+          expect(json).to eq(hour_json)
+          expect(response.headers['Cache-Control']).to eq "private, max-age=15"
+          expect(response.headers['ETag']).not_to be_nil
+          expect(response.headers['Last-Modified']).not_to be_nil
+
+          GET "/api/v1/groups/#{group.id}/charts", duration: :day
+
+          expect(response).to have_http_status(200)
+          expect(json).to eq(day_json)
+          expect(response.headers['Cache-Control']).to eq "public, max-age=900"
+          expect(response.headers['ETag']).not_to be_nil
+          expect(response.headers['Last-Modified']).not_to be_nil
+
+          GET "/api/v1/groups/#{group.id}/charts", duration: :day, timestamp: time - 1.day
+
+          expect(response).to have_http_status(200)
+          expect(json).to eq(yesterday_json)
+          expect(response.headers['Cache-Control']).to eq "public, max-age=86400"
+          expect(response.headers['ETag']).not_to be_nil
+          expect(response.headers['Last-Modified']).not_to be_nil
+
+          GET "/api/v1/groups/#{group.id}/charts", duration: :month
+
+          expect(response).to have_http_status(200)
+          expect(json).to eq(month_json)
+          expect(response.headers['Cache-Control']).to eq "public, max-age=3600"
+          expect(response.headers['ETag']).not_to be_nil
+          expect(response.headers['Last-Modified']).not_to be_nil
+
+          GET "/api/v1/groups/#{group.id}/charts", { duration: :year }, token
+
+          expect(response).to have_http_status(200)
+          expect(json).to eq(year_json)
+          expect(response.headers['Cache-Control']).to eq "private, max-age=86400"
+          expect(response.headers['ETag']).not_to be_nil
+          expect(response.headers['Last-Modified']).not_to be_nil
+        ensure
+          Timecop.return
+        end
+      end
+    end
+
+    let(:setup_readings) do
+      timestamp = Time.find_zone('Berlin').local(2016, 2, 1)
+      energy = 0
+      40.times do |i|
+        Fabricate(:reading,
+                  source: [Reading::SLP, Reading::SEP_BHKW][i % 2],
+                  timestamp: timestamp,
+                  energy_milliwatt_hour: energy,
+                  power_milliwatt: 930000 + i,
+                  reason: Reading::REGULAR_READING,
+                  quality: Reading::READ_OUT
+                 )
+        energy += 1200000
+        timestamp += 15.minutes
+      end
+      5.times do |i|
+        Fabricate(:reading,
+                  source: [Reading::SLP, Reading::SEP_BHKW][i % 2],
+                  timestamp: timestamp,
+                  energy_milliwatt_hour: energy,
+                  power_milliwatt: 930000 + i,
+                  reason: Reading::REGULAR_READING,
+                  quality: Reading::READ_OUT
+                 )
+        energy += 1200000
+        timestamp += 1.hour
+      end
+      5.times do |i|
+        Fabricate(:reading,
+                  source: [Reading::SLP, Reading::SEP_BHKW][i % 2],
+                  timestamp: timestamp,
+                  energy_milliwatt_hour: energy,
+                  power_milliwatt: 930000 + i,
+                  reason: Reading::REGULAR_READING,
+                  quality: Reading::READ_OUT
+                 )
+        energy += 1200000
+        timestamp += 1.day
+      end
+      5.times do |i|
+        Fabricate(:reading,
+                  source: [Reading::SLP, Reading::SEP_BHKW][i % 2],
+                  timestamp: timestamp,
+                  energy_milliwatt_hour: energy,
+                  power_milliwatt: 930000 + i,
+                  reason: Reading::REGULAR_READING,
+                  quality: Reading::READ_OUT
+                 )
+        energy += 1200000
+        timestamp += 1.month
+      end
+    end
+
+    let(:profile_hour_json) do
+      {
+        "units"=>"milliwatt",
+        "resource_id"=> profile_group.id,
+        "in"=>[{"timestamp"=>1454284800.0, "value"=>930004.0},
+               {"timestamp"=>1454286600.0, "value"=>930006.0}],
+        "out"=>[]
+      }
+    end
+    let(:profile_day_json) do
+      {
+        "units"=>"milliwatt",
+        "resource_id"=> profile_group.id,
+        "out"=>[{"timestamp"=>1454282100.0, "value"=>930001.0},
+               {"timestamp"=>1454283900.0, "value"=>930003.0},
+               {"timestamp"=>1454285700.0, "value"=>930005.0}],
+        "in"=>[]
+      }
+    end
+    let(:profile_yesterday_json) do
+      {
+        "units"=>"milliwatt",
+        "resource_id"=> profile_group.id,
+        "in"=>[{"timestamp"=>1454281200.0, "value"=>930000.0},
+               {"timestamp"=>1454283000.0, "value"=>930002.0},
+               {"timestamp"=>1454284800.0, "value"=>930004.0},
+               {"timestamp"=>1454286600.0, "value"=>930006.0},
+               {"timestamp"=>1454288400.0, "value"=>930008.0},
+               {"timestamp"=>1454290200.0, "value"=>930010.0},
+               {"timestamp"=>1454292000.0, "value"=>930012.0},
+               {"timestamp"=>1454293800.0, "value"=>930014.0},
+               {"timestamp"=>1454295600.0, "value"=>930016.0},
+               {"timestamp"=>1454297400.0, "value"=>930018.0},
+               {"timestamp"=>1454299200.0, "value"=>930020.0},
+               {"timestamp"=>1454301000.0, "value"=>930022.0},
+               {"timestamp"=>1454302800.0, "value"=>930024.0},
+               {"timestamp"=>1454304600.0, "value"=>930026.0},
+               {"timestamp"=>1454306400.0, "value"=>930028.0},
+               {"timestamp"=>1454308200.0, "value"=>930030.0},
+               {"timestamp"=>1454310000.0, "value"=>930032.0},
+               {"timestamp"=>1454311800.0, "value"=>930034.0},
+               {"timestamp"=>1454313600.0, "value"=>930036.0},
+               {"timestamp"=>1454315400.0, "value"=>930038.0},
+               {"timestamp"=>1454317200.0, "value"=>930000.0},
+               {"timestamp"=>1454324400.0, "value"=>930002.0},
+               {"timestamp"=>1454331600.0, "value"=>930004.0},
+               {"timestamp"=>1454335200.0, "value"=>930000.0}],
+        "out"=>[]
+      }
+    end
+    let(:profile_month_json) do
+      {
+        "units"=>"milliwatt_hour",
+        "resource_id"=> profile_group.id,
+        "out"=>[{"timestamp"=>1454282100.0, "value"=>4800000.0}],
+        "in"=>[]
+      }
+    end
+    let(:profile_year_json) do
+      {
+        "units"=>"milliwatt_hour",
+        "resource_id"=> profile_group.id,
+        "in"=>[{"timestamp"=>1454281200.0, "value"=>7200000.0}],
+        "out"=>[]
+      }
+    end
+
+    xit 'standard profile' do
+      setup_readings
+      begin
+        Timecop.freeze(time)
+
+        GET "/api/v1/groups/#{profile_group.id}/charts", { duration: :hour }, token
+
+        expect(response).to have_http_status(200)
+        expect(json).to eq(profile_hour_json)
+        expect(response.headers['Cache-Control']).to eq "private, max-age=15"
+        expect(response.headers['ETag']).not_to be_nil
+        expect(response.headers['Last-Modified']).not_to be_nil
+
+        GET  "/api/v1/groups/#{profile_group.id}/charts", duration: :day
+
+        expect(response).to have_http_status(200)
+        expect(json).to eq(profile_day_json)
+        expect(response.headers['Cache-Control']).to eq "public, max-age=900"
+        expect(response.headers['ETag']).not_to be_nil
+        expect(response.headers['Last-Modified']).not_to be_nil
+
+        GET  "/api/v1/groups/#{profile_group.id}/charts", duration: :day, timestamp: time - 1.day
+
+        expect(response).to have_http_status(200)
+        expect(json).to eq(profile_yesterday_json)
+        expect(response.headers['Cache-Control']).to eq "public, max-age=86400"
+        expect(response.headers['ETag']).not_to be_nil
+        expect(response.headers['Last-Modified']).not_to be_nil
+
+        GET  "/api/v1/groups/#{profile_group.id}/charts", duration: :month
+
+        expect(response).to have_http_status(200)
+        expect(json).to eq(profile_month_json)
+        expect(response.headers['Cache-Control']).to eq "public, max-age=3600"
+        expect(response.headers['ETag']).not_to be_nil
+        expect(response.headers['Last-Modified']).not_to be_nil
+
+        GET  "/api/v1/groups/#{profile_group.id}/charts", { duration: :year }, token
+
+        expect(json).to eq(profile_year_json)
+        expect(response).to have_http_status(200)
+        expect(response.headers['Cache-Control']).to eq "private, max-age=86400"
+        expect(response.headers['ETag']).not_to be_nil
+        expect(response.headers['Last-Modified']).not_to be_nil
+      ensure
+        Timecop.return
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/register_aggregation_spec.rb
+++ b/spec/requests/api/v1/register_aggregation_spec.rb
@@ -1,0 +1,503 @@
+describe "/registers" do
+
+  let(:discovergy_meter) do
+    meter = Fabricate(:easymeter_60139082) # in_out meter
+    meter.registers.each { |r| r.update(readable: :world) }
+    # TODO what to do with the in-out fact ?
+    Fabricate(:discovergy_broker, resource: meter, external_id: "EASYMETER_60139082", mode: :in_out)
+    meter
+  end
+
+  let(:group) do
+    group = Fabricate(:group)
+    group.registers += discovergy_meter.registers
+    group.registers += slp_meter.registers
+    group
+  end
+
+  let(:input_register) { discovergy_meter.input_register }
+
+  let(:output_register) { discovergy_meter.output_register }
+
+  let(:slp_register) do
+    register = Fabricate(:input_meter).input_register
+    register.update(readable: :world)
+    register
+  end
+
+  let(:sep_register) do
+    register = Fabricate(:output_meter).output_register
+    register.update(readable: :world)
+    register
+  end
+
+  let(:token) { Fabricate(:full_access_token_as_admin) }
+
+  let(:time) { Time.find_zone('Berlin').local(2016, 2, 1, 1, 30, 1) }
+
+  let(:denied_json) do
+    {
+      "errors" => [{"title"=>"Permission Denied",
+                    "detail"=>"retrieve Register::Base: permission denied for User: --anonymous--"}]
+    }
+  end
+  let(:not_found_json) do
+    {
+      "errors" => [{"title"=>"Permission Denied",
+                    "detail"=>"Register::Base: bla-bla-bla not found"}]
+    }
+  end
+
+  context '/ticker' do
+
+    let(:out_json) do
+      { "timestamp" => 1467446702.088,
+        "value" => 1200640.0,
+        "resource_id" => output_register.id,
+        "mode" => "out",
+        "expires_at"=> 1454286616.0 }
+    end
+
+    let(:in_json) do
+      { "timestamp" => 1467446702.088,
+        "value" => 1100640.0,
+        "resource_id" => input_register.id,
+        "mode" => "in",
+        "expires_at"=> 1454286616.0 }
+    end
+
+    let(:slp_json) do
+      { "timestamp" => 1454287500.0,
+        "value" => 930007.0,
+        "resource_id" => slp_register.id,
+        "mode"=>"in",
+        # last_readings + 15.minutes - 1 (as time is 01:30:01)
+        "expires_at"=> (time + 15.minutes - 1).to_f }
+    end
+
+    it 'fails without permissions' do
+      input_register.update(readable: :members)
+      GET "/api/v1/registers/#{input_register.id}/ticker"
+      expect(response).to have_http_status(403)
+      expect(json).to eq denied_json
+    end
+
+    it 'fails with not found' do
+      GET "/api/v1/registers/bla-bla-bla/ticker"
+      expect(response).to have_http_status(404)
+      expect(json).to eq not_found_json
+    end
+
+    it 'discovergy' do
+      VCR.use_cassette("request/api/v1/discovergy") do
+
+        time = Time.find_zone('Berlin').local(2016, 2, 1, 1, 30, 1)
+        begin
+          Timecop.freeze(time)
+
+          GET "/api/v1/registers/#{input_register.id}/ticker"
+
+          expect(response).to have_http_status(200)
+          expect(json).to eq(in_json)
+          expect(response.headers['Expires']).not_to be_nil
+          expect(response.headers['Cache-Control']).to eq "public, max-age=15"
+          expect(response.headers['ETag']).not_to be_nil
+          expect(response.headers['Last-Modified']).not_to be_nil
+
+          GET "/api/v1/registers/#{output_register.id}/ticker", {}, token
+
+          expect(response).to have_http_status(200)
+          expect(json).to eq(out_json)
+          expect(expires = response.headers['Expires']).not_to be_nil
+          expect(response.headers['Cache-Control']).to eq "private, max-age=15"
+          expect(etag = response.headers['ETag']).not_to be_nil
+          expect(modified = response.headers['Last-Modified']).not_to be_nil
+
+          # cache hit
+          Timecop.freeze(time + 5)
+          GET "/api/v1/registers/#{output_register.id}/ticker", {}, token
+
+          expect(response).to have_http_status(200)
+          expect(json).to eq(out_json)          
+          expect(response.headers['Expires']).to eq expires
+          expect(response.headers['ETag']).to eq etag
+          expect(response.headers['Last-Modified']).to eq modified
+
+          # no cache hit
+          Timecop.freeze(time + 25)
+          GET "/api/v1/registers/#{output_register.id}/ticker"
+
+          expect(response).to have_http_status(200)
+          expect(json).to eq({ "timestamp" => 1467446703.088,
+                               "value" => 1300640.0,
+                               "resource_id" => output_register.id,
+                               "mode" => "out",
+                               "expires_at" => 1454286641.0 })
+          expect(response.headers['Expires']).not_to eq expires
+          expect(response.headers['ETag']).not_to eq etag
+          expect(response.headers['Last-Modified']).not_to eq modified    
+        ensure
+          Timecop.return
+        end
+      end
+    end
+
+    it 'standard profile' do
+      timestamp = Time.find_zone('Berlin').local(2016, 2, 1)
+      40.times do |i|
+        Fabricate(:reading,
+                  source: Reading::SLP,
+                  timestamp: timestamp,
+                  power_milliwatt: 930000 + i,
+                  reason: Reading::REGULAR_READING,
+                  quality: Reading::READ_OUT
+                 )
+        timestamp += 15.minutes
+      end
+
+      begin
+        Timecop.freeze(time)
+
+        GET "/api/v1/registers/#{slp_register.id}/ticker"
+
+        expect(response).to have_http_status(200)
+        expect(json).to eq(slp_json)
+        expect(response.headers['Expires']).not_to be_nil
+        # - 1 minute see 'time' and when readings were created
+        expect(response.headers['Cache-Control']).to eq "public, max-age=899"
+        expect(response.headers['ETag']).not_to be_nil
+        expect(response.headers['Last-Modified']).not_to be_nil
+
+        GET "/api/v1/registers/#{slp_register.id}/ticker", {}, token
+
+        expect(response).to have_http_status(200)
+        expect(json).to eq(slp_json)
+        expect(response.headers['Expires']).not_to be_nil
+        # - 1 minute see 'time' and when readings were created
+        expect(response.headers['Cache-Control']).to eq "private, max-age=899"
+        expect(response.headers['ETag']).not_to be_nil
+        expect(response.headers['Last-Modified']).not_to be_nil
+      ensure
+        Timecop.return
+      end
+    end
+
+    xit 'virtual' do
+    end
+  end
+
+  context '/charts' do
+    let(:hour_json) do
+      { "units" => "milliwatt",
+        "resource_id" => input_register.id,
+        "in" => [{"timestamp" => 1467446702.088, "value" => 1100640.0},
+                 {"timestamp" => 1467446702.288, "value" => 1100740.0}],
+        "out" => []
+      }
+    end
+
+    let(:day_json) do
+      { "units" => "milliwatt",
+        "resource_id" => output_register.id,
+        "out"=>[{"timestamp" => 1483225200.0, "value" => 511856.2932},
+                {"timestamp" => 1483226100.0, "value" => 540135.0148},
+                {"timestamp" => 1483227000.0, "value" => 614257.786},
+                {"timestamp" => 1483227900.0, "value" => 538366.4216}],
+        "in" => []
+      }
+    end
+    let(:yesterday_json) do
+      { "units"=>"milliwatt",
+        "resource_id" => input_register.id,
+        "in" => [{"timestamp" => 1483138800.0, "value" => 882855.2836},
+                 {"timestamp" => 1483139700.0, "value" => 305943.0632},
+                 {"timestamp" => 1483140600.0, "value" => 896316.3292},
+                 {"timestamp" => 1483141500.0, "value" => 894245.9292}],
+        "out" => []
+      }
+    end
+    let(:month_json) do
+      { "units" => "milliwatt_hour",
+        "resource_id" => output_register.id,
+        "in" => [],
+        "out" => [{"timestamp" => 1483225200.0, "value" => 17309965.2674},
+                  {"timestamp" => 1483311600.0, "value" => 26111829.0018}]
+      }
+    end
+    let(:year_json) do
+      { "units" => "milliwatt_hour",
+        "resource_id" => input_register.id,
+        "in" => [{"timestamp" => 1483225200.0, "value" => 21179442.0026},
+                 {"timestamp" => 1483311600.0, "value" => 21232911.5229}],
+        "out" => []
+      }
+    end
+    let(:missing_json) do
+      {
+        "errors" => [{"parameter" => "duration",
+                      "source" => {
+                        "pointer" => "/data/attributes/duration"},
+                      "title" => "Invalid Attribute",
+                      "detail" => "duration is missing"}]
+      }
+    end
+    let(:invalid_json) do
+      {
+        "errors" => [{"parameter" => "duration",
+                      "source" => {
+                        "pointer" => "/data/attributes/duration"},
+                      "title" => "Invalid Attribute",
+                      "detail" => "duration does not have a valid value"}]
+      }
+    end
+
+    it 'fails on missing duration parameter' do
+      GET "/api/v1/registers/#{input_register.id}/charts", {}, token
+      expect(response).to have_http_status(422)
+      expect(json).to eq missing_json
+    end
+    
+    it 'fails on wrong duration parameter' do
+      GET "/api/v1/registers/#{input_register.id}/charts", { duration: :century }
+      expect(response).to have_http_status(422)
+      expect(json).to eq invalid_json
+    end
+
+    it 'fails without permissions' do
+      register = Fabricate(:meter).registers.first
+      GET "/api/v1/registers/#{register.id}/charts", { duration: :day }
+      expect(response).to have_http_status(403)
+      expect(json).to eq denied_json
+    end
+
+    it 'fails with not found' do
+      register = Fabricate(:meter).registers.first
+      GET "/api/v1/registers/bla-bla-bla/ticker", { duration: :year }
+      expect(response).to have_http_status(404)
+      expect(json).to eq not_found_json
+    end
+
+    it 'discovergy' do
+      VCR.use_cassette("request/api/v1/discovergy") do
+        
+        begin
+          Timecop.freeze(time)
+
+          GET "/api/v1/registers/#{input_register.id}/charts", { duration: :hour }, token
+
+          expect(response).to have_http_status(200)
+          expect(json).to eq(hour_json)
+          expect(response.headers['Cache-Control']).to eq "private, max-age=15"
+          expect(response.headers['ETag']).not_to be_nil
+          expect(response.headers['Last-Modified']).not_to be_nil
+
+          GET  "/api/v1/registers/#{output_register.id}/charts", duration: :day
+
+          expect(response).to have_http_status(200)
+          expect(json).to eq(day_json)
+          expect(response.headers['Cache-Control']).to eq "public, max-age=900"
+          expect(response.headers['ETag']).not_to be_nil
+          expect(response.headers['Last-Modified']).not_to be_nil
+
+          GET  "/api/v1/registers/#{input_register.id}/charts", duration: :day, timestamp: time - 1.day
+
+          expect(response).to have_http_status(200)
+          expect(json).to eq(yesterday_json)
+          expect(response.headers['Cache-Control']).to eq "public, max-age=86400"
+          expect(response.headers['ETag']).not_to be_nil
+          expect(response.headers['Last-Modified']).not_to be_nil
+
+          GET  "/api/v1/registers/#{output_register.id}/charts", duration: :month
+
+          expect(response).to have_http_status(200)
+          expect(json).to eq(month_json)
+          expect(response.headers['Cache-Control']).to eq "public, max-age=3600"
+          expect(response.headers['ETag']).not_to be_nil
+          expect(response.headers['Last-Modified']).not_to be_nil
+
+          GET  "/api/v1/registers/#{input_register.id}/charts", { duration: :year }, token
+
+          expect(json).to eq(year_json)
+          expect(response).to have_http_status(200)
+          expect(response.headers['Cache-Control']).to eq "private, max-age=86400"
+          expect(response.headers['ETag']).not_to be_nil
+          expect(response.headers['Last-Modified']).not_to be_nil
+        ensure
+          Timecop.return
+        end
+      end
+    end
+
+    let(:setup_readings) do
+      timestamp = Time.find_zone('Berlin').local(2016, 2, 1)
+      energy = 0
+      40.times do |i|
+        Fabricate(:reading,
+                  source: [Reading::SLP, Reading::SEP_BHKW][i % 2],
+                  timestamp: timestamp,
+                  energy_milliwatt_hour: energy,
+                  power_milliwatt: 930000 + i,
+                  reason: Reading::REGULAR_READING,
+                  quality: Reading::READ_OUT
+                 )
+        energy += 1200000
+        timestamp += 15.minutes
+      end
+      5.times do |i|
+        Fabricate(:reading,
+                  source: [Reading::SLP, Reading::SEP_BHKW][i % 2],
+                  timestamp: timestamp,
+                  energy_milliwatt_hour: energy,
+                  power_milliwatt: 930000 + i,
+                  reason: Reading::REGULAR_READING,
+                  quality: Reading::READ_OUT
+                 )
+        energy += 1200000
+        timestamp += 1.hour
+      end
+      5.times do |i|
+        Fabricate(:reading,
+                  source: [Reading::SLP, Reading::SEP_BHKW][i % 2],
+                  timestamp: timestamp,
+                  energy_milliwatt_hour: energy,
+                  power_milliwatt: 930000 + i,
+                  reason: Reading::REGULAR_READING,
+                  quality: Reading::READ_OUT
+                 )
+        energy += 1200000
+        timestamp += 1.day
+      end
+      5.times do |i|
+        Fabricate(:reading,
+                  source: [Reading::SLP, Reading::SEP_BHKW][i % 2],
+                  timestamp: timestamp,
+                  energy_milliwatt_hour: energy,
+                  power_milliwatt: 930000 + i,
+                  reason: Reading::REGULAR_READING,
+                  quality: Reading::READ_OUT
+                 )
+        energy += 1200000
+        timestamp += 1.month
+      end
+    end
+
+    let(:slp_hour_json) do
+      {
+        "units"=>"milliwatt",
+        "resource_id"=> slp_register.id,
+        "in"=>[{"timestamp"=>1454284800.0, "value"=>930004.0},
+               {"timestamp"=>1454286600.0, "value"=>930006.0}],
+        "out"=>[]
+      }
+    end
+    let(:sep_day_json) do
+      {
+        "units"=>"milliwatt",
+        "resource_id"=> sep_register.id,
+        "out"=>[{"timestamp"=>1454282100.0, "value"=>930001.0},
+               {"timestamp"=>1454283900.0, "value"=>930003.0},
+               {"timestamp"=>1454285700.0, "value"=>930005.0}],
+        "in"=>[]
+      }
+    end
+    let(:slp_yesterday_json) do
+      {
+        "units"=>"milliwatt",
+        "resource_id"=> slp_register.id,
+        "in"=>[{"timestamp"=>1454281200.0, "value"=>930000.0},
+               {"timestamp"=>1454283000.0, "value"=>930002.0},
+               {"timestamp"=>1454284800.0, "value"=>930004.0},
+               {"timestamp"=>1454286600.0, "value"=>930006.0},
+               {"timestamp"=>1454288400.0, "value"=>930008.0},
+               {"timestamp"=>1454290200.0, "value"=>930010.0},
+               {"timestamp"=>1454292000.0, "value"=>930012.0},
+               {"timestamp"=>1454293800.0, "value"=>930014.0},
+               {"timestamp"=>1454295600.0, "value"=>930016.0},
+               {"timestamp"=>1454297400.0, "value"=>930018.0},
+               {"timestamp"=>1454299200.0, "value"=>930020.0},
+               {"timestamp"=>1454301000.0, "value"=>930022.0},
+               {"timestamp"=>1454302800.0, "value"=>930024.0},
+               {"timestamp"=>1454304600.0, "value"=>930026.0},
+               {"timestamp"=>1454306400.0, "value"=>930028.0},
+               {"timestamp"=>1454308200.0, "value"=>930030.0},
+               {"timestamp"=>1454310000.0, "value"=>930032.0},
+               {"timestamp"=>1454311800.0, "value"=>930034.0},
+               {"timestamp"=>1454313600.0, "value"=>930036.0},
+               {"timestamp"=>1454315400.0, "value"=>930038.0},
+               {"timestamp"=>1454317200.0, "value"=>930000.0},
+               {"timestamp"=>1454324400.0, "value"=>930002.0},
+               {"timestamp"=>1454331600.0, "value"=>930004.0},
+               {"timestamp"=>1454335200.0, "value"=>930000.0}],
+        "out"=>[]
+      }
+    end
+    let(:sep_month_json) do
+      {
+        "units"=>"milliwatt_hour",
+        "resource_id"=> sep_register.id,
+        "out"=>[{"timestamp"=>1454282100.0, "value"=>4800000.0}],
+        "in"=>[]
+      }
+    end
+    let(:slp_year_json) do
+      {
+        "units"=>"milliwatt_hour",
+        "resource_id"=> slp_register.id,
+        "in"=>[{"timestamp"=>1454281200.0, "value"=>7200000.0}],
+        "out"=>[]
+      }
+    end
+
+    it 'standard profile' do
+      setup_readings
+      begin
+        Timecop.freeze(time)
+
+        GET "/api/v1/registers/#{slp_register.id}/charts", { duration: :hour }, token
+
+        expect(response).to have_http_status(200)
+        expect(json).to eq(slp_hour_json)
+        expect(response.headers['Cache-Control']).to eq "private, max-age=15"
+        expect(response.headers['ETag']).not_to be_nil
+        expect(response.headers['Last-Modified']).not_to be_nil
+
+        GET  "/api/v1/registers/#{sep_register.id}/charts", duration: :day
+
+        expect(response).to have_http_status(200)
+        expect(json).to eq(sep_day_json)
+        expect(response.headers['Cache-Control']).to eq "public, max-age=900"
+        expect(response.headers['ETag']).not_to be_nil
+        expect(response.headers['Last-Modified']).not_to be_nil
+
+        GET  "/api/v1/registers/#{slp_register.id}/charts", duration: :day, timestamp: time - 1.day
+
+        expect(response).to have_http_status(200)
+        expect(json).to eq(slp_yesterday_json)
+        expect(response.headers['Cache-Control']).to eq "public, max-age=86400"
+        expect(response.headers['ETag']).not_to be_nil
+        expect(response.headers['Last-Modified']).not_to be_nil
+
+        GET  "/api/v1/registers/#{sep_register.id}/charts", duration: :month
+
+        expect(response).to have_http_status(200)
+        expect(json).to eq(sep_month_json)
+        expect(response.headers['Cache-Control']).to eq "public, max-age=3600"
+        expect(response.headers['ETag']).not_to be_nil
+        expect(response.headers['Last-Modified']).not_to be_nil
+
+        GET  "/api/v1/registers/#{slp_register.id}/charts", { duration: :year }, token
+
+        expect(json).to eq(slp_year_json)
+        expect(response).to have_http_status(200)
+        expect(response.headers['Cache-Control']).to eq "private, max-age=86400"
+        expect(response.headers['ETag']).not_to be_nil
+        expect(response.headers['Last-Modified']).not_to be_nil
+      ensure
+        Timecop.return
+      end
+    end
+
+    xit 'virtual' do
+    end
+  end
+end

--- a/spec/support/requests_helper.rb
+++ b/spec/support/requests_helper.rb
@@ -29,6 +29,13 @@ module RequestsHelper
     end
   end
 
+  def GET(path, params = {}, token = nil)
+    if token
+      get_with_token(path, params, token.token)
+    else
+      get_without_token(path, params)
+    end
+  end
 
 
   def post_with_token(path, params={}, token)

--- a/spec/vcr_cassettes/request/api/v1/discovergy.yml
+++ b/spec/vcr_cassettes/request/api/v1/discovergy.yml
@@ -1,0 +1,1457 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.discovergy.com/public/v1/oauth1/consumer_token?client=buzzn+app+test
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      server:
+      - nginx/1.10.0
+      date:
+      - Wed, 01 Mar 2017 14:51:14 GMT
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      access-control-allow-origin:
+      - "*"
+      access-control-allow-methods:
+      - GET, POST, DELETE, PUT
+      access-control-allow-headers:
+      - X-Requested-With, Content-Type
+    body:
+      encoding: ASCII-8BIT
+      string: '{"key":"p1u8mkrf5gng5kjf2s4ihfhuuh","secret":"vb12nk7h8h26r45iu70b2jbhf2","owner":"buzzn
+        app test","attributes":{},"principal":null}'
+    http_version:
+  recorded_at: Mon, 01 Feb 2016 00:30:01 GMT
+- request:
+    method: post
+    uri: https://api.discovergy.com/public/v1/oauth1/request_token
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - OAuth gem v0.5.1
+      Content-Length:
+      - '0'
+      Authorization:
+      - OAuth oauth_callback="oob", oauth_consumer_key="p1u8mkrf5gng5kjf2s4ihfhuuh",
+        oauth_nonce="mZpcyLIBtRxCdffoUw5qy30qljD9k2u18fXNzA4RobU", oauth_signature="b6BSaeufIPZKkqKWg6SlaYy4%2BSc%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454286601", oauth_version="1.0"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.0
+      Date:
+      - Wed, 01 Mar 2017 14:51:14 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '126'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Headers:
+      - X-Requested-With, Content-Type
+    body:
+      encoding: UTF-8
+      string: oauth_token=5c39fb8941e14e598d4018f099ccfeb6&oauth_token_secret=f802c1d67d274820a5d02373ab20d8bf&oauth_callback_confirmed=true
+    http_version:
+  recorded_at: Mon, 01 Feb 2016 00:30:01 GMT
+- request:
+    method: get
+    uri: https://api.discovergy.com/public/v1/oauth1/authorize?email=team%40localpool.de&oauth_token=5c39fb8941e14e598d4018f099ccfeb6&password=Zebulon_4711
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      server:
+      - nginx/1.10.0
+      date:
+      - Wed, 01 Mar 2017 14:51:15 GMT
+      content-type:
+      - application/x-www-form-urlencoded
+      content-length:
+      - '47'
+      connection:
+      - keep-alive
+      access-control-allow-origin:
+      - "*"
+      access-control-allow-methods:
+      - GET, POST, DELETE, PUT
+      access-control-allow-headers:
+      - X-Requested-With, Content-Type
+    body:
+      encoding: UTF-8
+      string: oauth_verifier=fd7891c56616493c847d0f34bc195fc7
+    http_version:
+  recorded_at: Mon, 01 Feb 2016 00:30:01 GMT
+- request:
+    method: post
+    uri: https://api.discovergy.com/public/v1/oauth1/access_token
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - OAuth gem v0.5.1
+      Content-Length:
+      - '0'
+      Authorization:
+      - OAuth oauth_consumer_key="p1u8mkrf5gng5kjf2s4ihfhuuh", oauth_nonce="cMP2j88I24EjOH21LQeM8By8gNRGp4c1nlRm79bfTk",
+        oauth_signature="ALl%2BmNrITECZ9pJNPThzk%2BES8vI%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454286601", oauth_token="5c39fb8941e14e598d4018f099ccfeb6",
+        oauth_verifier="fd7891c56616493c847d0f34bc195fc7", oauth_version="1.0"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.0
+      Date:
+      - Wed, 01 Mar 2017 14:51:15 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Headers:
+      - X-Requested-With, Content-Type
+    body:
+      encoding: UTF-8
+      string: oauth_token=221a87aad37447e0a08a9195fa647f2c&oauth_token_secret=c075cac01bad4c7d886cb02c9b7bc7ed
+    http_version:
+  recorded_at: Mon, 01 Feb 2016 00:30:01 GMT
+- request:
+    method: get
+    uri: https://api.discovergy.com/public/v1/last_reading?each=false&fields=power&meterId=EASYMETER_60139082
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - OAuth gem v0.5.1
+      Authorization:
+      - OAuth oauth_consumer_key="p1u8mkrf5gng5kjf2s4ihfhuuh", oauth_nonce="6KhVZorpeNF8psXffsPlUW0QN6zXbG7E9A2Rt9uo0",
+        oauth_signature="Ly4ftP5XStCrGAhu4tGp%2F66uNso%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454286601", oauth_token="221a87aad37447e0a08a9195fa647f2c",
+        oauth_version="1.0"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.0
+      Date:
+      - Wed, 01 Mar 2017 20:15:10 GMT
+      Content-Type:
+      - text/html;charset=iso-8859-1
+      Content-Length:
+      - '340'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Headers:
+      - X-Requested-With, Content-Type
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+    body:
+      encoding: UTF-8
+      string: '{"time":1467446702088,"values":{"power":1100640}}'
+    http_version:
+  recorded_at: Mon, 01 Feb 2016 00:30:01 GMT
+- request:
+    method: get
+    uri: https://api.discovergy.com/public/v1/last_reading?each=false&fields=power&meterId=EASYMETER_60139082
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - OAuth gem v0.5.1
+      Authorization:
+      - OAuth oauth_consumer_key="p1u8mkrf5gng5kjf2s4ihfhuuh", oauth_nonce="6I6te9igb3dICx2dgLitM3LciWOOH4zkKYwtFXs",
+        oauth_signature="pNZn1zqLx78IJp3ZVGTvFNxZ6Gw%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454286601", oauth_token="221a87aad37447e0a08a9195fa647f2c",
+        oauth_version="1.0"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.0
+      Date:
+      - Wed, 01 Mar 2017 20:36:33 GMT
+      Content-Type:
+      - text/html;charset=iso-8859-1
+      Content-Length:
+      - '340'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Headers:
+      - X-Requested-With, Content-Type
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+    body:
+      encoding: UTF-8
+      string: '{"time":1467446702088,"values":{"power":-1200640}}'
+    http_version:
+  recorded_at: Mon, 01 Feb 2016 00:30:01 GMT
+- request:
+    method: get
+    uri: https://api.discovergy.com/public/v1/last_reading?each=false&fields=power&meterId=EASYMETER_60139082
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - OAuth gem v0.5.1
+      Authorization:
+      - OAuth oauth_consumer_key="p1u8mkrf5gng5kjf2s4ihfhuuh", oauth_nonce="6I6te9igb3dICx2dgLitM3LciWOOH4zkKYwtFXs",
+        oauth_signature="pNZn1zqLx78IJp3ZVGTvFNxZ6Gw%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454286601", oauth_token="221a87aad37447e0a08a9195fa647f2c",
+        oauth_version="1.0"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.0
+      Date:
+      - Wed, 01 Mar 2017 20:36:33 GMT
+      Content-Type:
+      - text/html;charset=iso-8859-1
+      Content-Length:
+      - '340'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Headers:
+      - X-Requested-With, Content-Type
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+    body:
+      encoding: UTF-8
+      string: '{"time":1467446703088,"values":{"power":-1300640}}'
+    http_version:
+  recorded_at: Mon, 01 Feb 2016 00:30:01 GMT
+- request:
+    method: get
+    uri: https://api.discovergy.com/public/v1/last_reading?each=false&fields=power&meterId=EASYMETER_60139082
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - OAuth gem v0.5.1
+      Authorization:
+      - OAuth oauth_consumer_key="p1u8mkrf5gng5kjf2s4ihfhuuh", oauth_nonce="6I6te9igb3dICx2dgLitM3LciWOOH4zkKYwtFXs",
+        oauth_signature="pNZn1zqLx78IJp3ZVGTvFNxZ6Gw%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454286601", oauth_token="221a87aad37447e0a08a9195fa647f2c",
+        oauth_version="1.0"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.0
+      Date:
+      - Wed, 01 Mar 2017 20:36:33 GMT
+      Content-Type:
+      - text/html;charset=iso-8859-1
+      Content-Length:
+      - '340'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Headers:
+      - X-Requested-With, Content-Type
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+    body:
+      encoding: UTF-8
+      string: '{"time":1467446702088,"values":{"power":-1200640}}'
+    http_version:
+  recorded_at: Mon, 01 Feb 2016 00:30:01 GMT
+- request:
+    method: get
+    uri: https://api.discovergy.com/public/v1/last_reading?each=false&fields=power&meterId=EASYMETER_60139082
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - OAuth gem v0.5.1
+      Authorization:
+      - OAuth oauth_consumer_key="p1u8mkrf5gng5kjf2s4ihfhuuh", oauth_nonce="6KhVZorpeNF8psXffsPlUW0QN6zXbG7E9A2Rt9uo0",
+        oauth_signature="Ly4ftP5XStCrGAhu4tGp%2F66uNso%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454286601", oauth_token="221a87aad37447e0a08a9195fa647f2c",
+        oauth_version="1.0"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.0
+      Date:
+      - Wed, 01 Mar 2017 20:15:10 GMT
+      Content-Type:
+      - text/html;charset=iso-8859-1
+      Content-Length:
+      - '340'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Headers:
+      - X-Requested-With, Content-Type
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+    body:
+      encoding: UTF-8
+      string: '{"time":1467446702188,"values":{"power":2100640}}'
+    http_version:
+  recorded_at: Mon, 01 Feb 2016 00:30:01 GMT
+- request:
+    method: get
+    uri: https://api.discovergy.com/public/v1/last_reading?each=false&fields=power&meterId=EASYMETER_60139082
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - OAuth gem v0.5.1
+      Authorization:
+      - OAuth oauth_consumer_key="p1u8mkrf5gng5kjf2s4ihfhuuh", oauth_nonce="6I6te9igb3dICx2dgLitM3LciWOOH4zkKYwtFXs",
+        oauth_signature="pNZn1zqLx78IJp3ZVGTvFNxZ6Gw%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454286601", oauth_token="221a87aad37447e0a08a9195fa647f2c",
+        oauth_version="1.0"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.0
+      Date:
+      - Wed, 01 Mar 2017 20:36:33 GMT
+      Content-Type:
+      - text/html;charset=iso-8859-1
+      Content-Length:
+      - '340'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Headers:
+      - X-Requested-With, Content-Type
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+    body:
+      encoding: UTF-8
+      string: '{"time":1467446702188,"values":{"power":-2200640}}'
+    http_version:
+  recorded_at: Mon, 01 Feb 2016 00:30:01 GMT
+- request:
+    method: get
+    uri: https://api.discovergy.com/public/v1/last_reading?each=false&fields=power&meterId=EASYMETER_60139082
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - OAuth gem v0.5.1
+      Authorization:
+      - OAuth oauth_consumer_key="p1u8mkrf5gng5kjf2s4ihfhuuh", oauth_nonce="6I6te9igb3dICx2dgLitM3LciWOOH4zkKYwtFXs",
+        oauth_signature="pNZn1zqLx78IJp3ZVGTvFNxZ6Gw%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454286601", oauth_token="221a87aad37447e0a08a9195fa647f2c",
+        oauth_version="1.0"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.0
+      Date:
+      - Wed, 01 Mar 2017 20:36:33 GMT
+      Content-Type:
+      - text/html;charset=iso-8859-1
+      Content-Length:
+      - '340'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Headers:
+      - X-Requested-With, Content-Type
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+    body:
+      encoding: UTF-8
+      string: '{"time":1467446702188,"values":{"power":-2200640}}'
+    http_version:
+  recorded_at: Mon, 01 Feb 2016 00:30:01 GMT
+- request:
+    method: get
+    uri: https://api.discovergy.com/public/v1/last_reading?each=false&fields=power&meterId=EASYMETER_60139082
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - OAuth gem v0.5.1
+      Authorization:
+      - OAuth oauth_consumer_key="p1u8mkrf5gng5kjf2s4ihfhuuh", oauth_nonce="6I6te9igb3dICx2dgLitM3LciWOOH4zkKYwtFXs",
+        oauth_signature="pNZn1zqLx78IJp3ZVGTvFNxZ6Gw%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454286601", oauth_token="221a87aad37447e0a08a9195fa647f2c",
+        oauth_version="1.0"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.0
+      Date:
+      - Wed, 01 Mar 2017 20:36:33 GMT
+      Content-Type:
+      - text/html;charset=iso-8859-1
+      Content-Length:
+      - '340'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Headers:
+      - X-Requested-With, Content-Type
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+    body:
+      encoding: UTF-8
+      string: '{"time":1467446703188,"values":{"power":-2300640}}'
+    http_version:
+  recorded_at: Mon, 01 Feb 2016 00:30:01 GMT
+- request:
+    method: get
+    uri: https://api.discovergy.com/public/v1/readings?each=false&fields=power&from=1454284800000&meterId=EASYMETER_60139082&resolution=raw&to=1454288400000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - OAuth gem v0.5.1
+      Authorization:
+      - OAuth oauth_consumer_key="e2m206tufotddbts9lj6g16apk", oauth_nonce="76bQizT0Wky9Jj1fvB2dVppwzatsk2E0iROHi4o9c9I",
+        oauth_signature="Ynt2AZo90b7S0QTr1pmN8G7O8v8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1467446702", oauth_token="468bdc9aefc84702b84934d969a14d9a",
+        oauth_version="1.0"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.0
+      Date:
+      - Fri, 02 Dec 2016 10:10:56 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '49'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Headers:
+      - X-Requested-With, Content-Type
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+    body:
+      encoding: UTF-8
+      string: "[{\"time\":1467446702088,\"values\":{\"power\":1100640}},{\"time\":1467446702288,\"values\":{\"power\":1100740}}]"
+    http_version:
+  recorded_at: Sat, 02 Jul 2016 08:05:03 GMT
+- request:
+    method: get
+    uri: https://api.discovergy.com/public/v1/readings?each=false&fields=power&from=1454284800000&meterId=EASYMETER_60139082&resolution=raw&to=1454288400000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - OAuth gem v0.5.1
+      Authorization:
+      - OAuth oauth_consumer_key="e2m206tufotddbts9lj6g16apk", oauth_nonce="76bQizT0Wky9Jj1fvB2dVppwzatsk2E0iROHi4o9c9I",
+        oauth_signature="Ynt2AZo90b7S0QTr1pmN8G7O8v8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1467446702", oauth_token="468bdc9aefc84702b84934d969a14d9a",
+        oauth_version="1.0"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.0
+      Date:
+      - Fri, 02 Dec 2016 10:10:56 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '49'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Headers:
+      - X-Requested-With, Content-Type
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+    body:
+      encoding: UTF-8
+      string: "[{\"time\":1467446702088,\"values\":{\"power\":1100640}},{\"time\":1467446702288,\"values\":{\"power\":1100740}}]"
+    http_version:
+  recorded_at: Sat, 02 Jul 2016 08:05:03 GMT
+- request:
+    method: get
+    uri: https://api.discovergy.com/public/v1/readings?each=false&fields=power&from=1454284800000&meterId=EASYMETER_60139082&resolution=raw&to=1454288400000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - OAuth gem v0.5.1
+      Authorization:
+      - OAuth oauth_consumer_key="e2m206tufotddbts9lj6g16apk", oauth_nonce="76bQizT0Wky9Jj1fvB2dVppwzatsk2E0iROHi4o9c9I",
+        oauth_signature="Ynt2AZo90b7S0QTr1pmN8G7O8v8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1467446702", oauth_token="468bdc9aefc84702b84934d969a14d9a",
+        oauth_version="1.0"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.0
+      Date:
+      - Fri, 02 Dec 2016 10:10:56 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '49'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Headers:
+      - X-Requested-With, Content-Type
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+    body:
+      encoding: UTF-8
+      string: "[{\"time\":1467446702088,\"values\":{\"power\":1100640}},{\"time\":1467446702288,\"values\":{\"power\":1100740}}]"
+    http_version:
+  recorded_at: Sat, 02 Jul 2016 08:05:03 GMT
+- request:
+    method: get
+    uri: https://api.discovergy.com/public/v1/readings?each=false&fields=power&from=1454284800000&meterId=EASYMETER_60139082&resolution=raw&to=1454288400000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - OAuth gem v0.5.1
+      Authorization:
+      - OAuth oauth_consumer_key="e2m206tufotddbts9lj6g16apk", oauth_nonce="76bQizT0Wky9Jj1fvB2dVppwzatsk2E0iROHi4o9c9I",
+        oauth_signature="Ynt2AZo90b7S0QTr1pmN8G7O8v8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1467446702", oauth_token="468bdc9aefc84702b84934d969a14d9a",
+        oauth_version="1.0"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.0
+      Date:
+      - Fri, 02 Dec 2016 10:10:56 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '49'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Headers:
+      - X-Requested-With, Content-Type
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+    body:
+      encoding: UTF-8
+      string: "[{\"time\":1467446702088,\"values\":{\"power\":1100640}},{\"time\":1467446702288,\"values\":{\"power\":1100740}}]"
+    http_version:
+  recorded_at: Sat, 02 Jul 2016 08:05:03 GMT
+- request:
+    method: get
+    uri: https://api.discovergy.com/public/v1/readings?each=false&fields=energyOut&from=1454281200000&meterId=EASYMETER_60139082&resolution=fifteen_minutes&to=1454367600000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - OAuth gem v0.5.1
+      Authorization:
+      - OAuth oauth_consumer_key="e2m206tufotddbts9lj6g16apk", oauth_nonce="76bQizT0Wky9Jj1fvB2dVppwzatsk2E0iROHi4o9c9I",
+        oauth_signature="Ynt2AZo90b7S0QTr1pmN8G7O8v8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1467446702", oauth_token="468bdc9aefc84702b84934d969a14d9a",
+        oauth_version="1.0"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.0
+      Date:
+      - Fri, 02 Dec 2016 10:10:56 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '49'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Headers:
+      - X-Requested-With, Content-Type
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+    body:
+      encoding: UTF-8
+      string: "[{\"time\":1483225200000,\"values\":{\"energyOut\":214993344475050}},{\"time\":1483226100000,\"values\":{\"energyOut\":214994624115783}},{\"time\":1483227000000,\"values\":{\"energyOut\":214995974453320}},{\"time\":1483227900000,\"values\":{\"energyOut\":214997510097785}},{\"time\":1483228800000,\"values\":{\"energyOut\":214998856013839}}]"
+    http_version:
+  recorded_at: Sat, 02 Jul 2016 08:05:03 GMT
+- request:
+    method: get
+    uri: https://api.discovergy.com/public/v1/readings?each=false&fields=energy&from=1454194800000&meterId=EASYMETER_60139082&resolution=fifteen_minutes&to=1454281200000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - OAuth gem v0.5.1
+      Authorization:
+      - OAuth oauth_consumer_key="e2m206tufotddbts9lj6g16apk", oauth_nonce="76bQizT0Wky9Jj1fvB2dVppwzatsk2E0iROHi4o9c9I",
+        oauth_signature="Ynt2AZo90b7S0QTr1pmN8G7O8v8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1467446702", oauth_token="468bdc9aefc84702b84934d969a14d9a",
+        oauth_version="1.0"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.0
+      Date:
+      - Fri, 02 Dec 2016 10:10:56 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '49'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Headers:
+      - X-Requested-With, Content-Type
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+    body:
+      encoding: UTF-8
+      string: "[{\"time\":1483138800000,\"values\":{\"energy\":140117307511418}},{\"time\":1483139700000,\"values\":{\"energy\":140119514649627}},{\"time\":1483140600000,\"values\":{\"energy\":140120279507285}},{\"time\":1483141500000,\"values\":{\"energy\":140122520298108}},{\"time\":1483142400000,\"values\":{\"energy\":140124755912931}}]"
+    http_version:
+  recorded_at: Sat, 02 Jul 2016 08:05:03 GMT
+- request:
+    method: get
+    uri: https://api.discovergy.com/public/v1/readings?each=false&fields=energy&from=1454281200000&meterId=EASYMETER_60139082&resolution=fifteen_minutes&to=1454367600000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - OAuth gem v0.5.1
+      Authorization:
+      - OAuth oauth_consumer_key="e2m206tufotddbts9lj6g16apk", oauth_nonce="76bQizT0Wky9Jj1fvB2dVppwzatsk2E0iROHi4o9c9I",
+        oauth_signature="Ynt2AZo90b7S0QTr1pmN8G7O8v8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1467446702", oauth_token="468bdc9aefc84702b84934d969a14d9a",
+        oauth_version="1.0"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.0
+      Date:
+      - Fri, 02 Dec 2016 10:10:56 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '49'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Headers:
+      - X-Requested-With, Content-Type
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+    body:
+      encoding: UTF-8
+      string: "[{\"time\":1483225200000,\"values\":{\"energyOut\":214993344475050}},{\"time\":1483226100000,\"values\":{\"energyOut\":214994624115783}},{\"time\":1483227000000,\"values\":{\"energyOut\":214995974453320}},{\"time\":1483227900000,\"values\":{\"energyOut\":214997510097785}},{\"time\":1483228800000,\"values\":{\"energyOut\":214998856013839}}]"
+    http_version:
+  recorded_at: Sat, 02 Jul 2016 08:05:03 GMT
+- request:
+    method: get
+    uri: https://api.discovergy.com/public/v1/readings?each=false&fields=energy&from=1454281200000&meterId=EASYMETER_60139082&resolution=fifteen_minutes&to=1454367600000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - OAuth gem v0.5.1
+      Authorization:
+      - OAuth oauth_consumer_key="e2m206tufotddbts9lj6g16apk", oauth_nonce="76bQizT0Wky9Jj1fvB2dVppwzatsk2E0iROHi4o9c9I",
+        oauth_signature="Ynt2AZo90b7S0QTr1pmN8G7O8v8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1467446702", oauth_token="468bdc9aefc84702b84934d969a14d9a",
+        oauth_version="1.0"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.0
+      Date:
+      - Fri, 02 Dec 2016 10:10:56 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '49'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Headers:
+      - X-Requested-With, Content-Type
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+    body:
+      encoding: UTF-8
+      string: "[{\"time\":1483138800000,\"values\":{\"energy\":140117307511418}},{\"time\":1483139700000,\"values\":{\"energy\":140119514649627}},{\"time\":1483140600000,\"values\":{\"energy\":140120279507285}},{\"time\":1483141500000,\"values\":{\"energy\":140122520298108}},{\"time\":1483142400000,\"values\":{\"energy\":140124755912931}}]"
+    http_version:
+  recorded_at: Sat, 02 Jul 2016 08:05:03 GMT
+- request:
+    method: get
+    uri: https://api.discovergy.com/public/v1/readings?each=false&fields=energy&from=1454194800000&meterId=EASYMETER_60139082&resolution=fifteen_minutes&to=1454281200000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - OAuth gem v0.5.1
+      Authorization:
+      - OAuth oauth_consumer_key="e2m206tufotddbts9lj6g16apk", oauth_nonce="76bQizT0Wky9Jj1fvB2dVppwzatsk2E0iROHi4o9c9I",
+        oauth_signature="Ynt2AZo90b7S0QTr1pmN8G7O8v8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1467446702", oauth_token="468bdc9aefc84702b84934d969a14d9a",
+        oauth_version="1.0"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.0
+      Date:
+      - Fri, 02 Dec 2016 10:10:56 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '49'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Headers:
+      - X-Requested-With, Content-Type
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+    body:
+      encoding: UTF-8
+      string: "[{\"time\":1483225200000,\"values\":{\"energyOut\":214993344475050}},{\"time\":1483226100000,\"values\":{\"energyOut\":214994624115783}},{\"time\":1483227000000,\"values\":{\"energyOut\":214995974453320}},{\"time\":1483227900000,\"values\":{\"energyOut\":214997510097785}},{\"time\":1483228800000,\"values\":{\"energyOut\":214998856013839}}]"
+    http_version:
+  recorded_at: Sat, 02 Jul 2016 08:05:03 GMT
+- request:
+    method: get
+    uri: https://api.discovergy.com/public/v1/readings?each=false&fields=energyOut&from=1454281200000&meterId=EASYMETER_60139082&resolution=fifteen_minutes&to=1454367600000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - OAuth gem v0.5.1
+      Authorization:
+      - OAuth oauth_consumer_key="e2m206tufotddbts9lj6g16apk", oauth_nonce="76bQizT0Wky9Jj1fvB2dVppwzatsk2E0iROHi4o9c9I",
+        oauth_signature="Ynt2AZo90b7S0QTr1pmN8G7O8v8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1467446702", oauth_token="468bdc9aefc84702b84934d969a14d9a",
+        oauth_version="1.0"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.0
+      Date:
+      - Fri, 02 Dec 2016 10:10:56 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '49'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Headers:
+      - X-Requested-With, Content-Type
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+    body:
+      encoding: UTF-8
+      string: "[{\"time\":1483225200000,\"values\":{\"energyOut\":214993344475050}},{\"time\":1483226100000,\"values\":{\"energyOut\":214994624115783}},{\"time\":1483227000000,\"values\":{\"energyOut\":214995974453320}},{\"time\":1483227900000,\"values\":{\"energyOut\":214997510097785}},{\"time\":1483228800000,\"values\":{\"energyOut\":214998856013839}}]"
+    http_version:
+  recorded_at: Sat, 02 Jul 2016 08:05:03 GMT
+- request:
+    method: get
+    uri: https://api.discovergy.com/public/v1/readings?each=false&fields=energyOut&from=1454194800000&meterId=EASYMETER_60139082&resolution=fifteen_minutes&to=1454281200000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - OAuth gem v0.5.1
+      Authorization:
+      - OAuth oauth_consumer_key="e2m206tufotddbts9lj6g16apk", oauth_nonce="76bQizT0Wky9Jj1fvB2dVppwzatsk2E0iROHi4o9c9I",
+        oauth_signature="Ynt2AZo90b7S0QTr1pmN8G7O8v8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1467446702", oauth_token="468bdc9aefc84702b84934d969a14d9a",
+        oauth_version="1.0"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.0
+      Date:
+      - Fri, 02 Dec 2016 10:10:56 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '49'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Headers:
+      - X-Requested-With, Content-Type
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+    body:
+      encoding: UTF-8
+      string: "[{\"time\":1483225200000,\"values\":{\"energyOut\":214993344475050}},{\"time\":1483226100000,\"values\":{\"energyOut\":214994624115783}},{\"time\":1483227000000,\"values\":{\"energyOut\":214995974453320}},{\"time\":1483227900000,\"values\":{\"energyOut\":214997510097785}},{\"time\":1483228800000,\"values\":{\"energyOut\":214998856013839}}]"
+    http_version:
+  recorded_at: Sat, 02 Jul 2016 08:05:03 GMT
+- request:
+    method: get
+    uri: https://api.discovergy.com/public/v1/readings?each=false&fields=energyOut&from=1454194800000&meterId=EASYMETER_60139082&resolution=fifteen_minutes&to=1454281200000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - OAuth gem v0.5.1
+      Authorization:
+      - OAuth oauth_consumer_key="e2m206tufotddbts9lj6g16apk", oauth_nonce="76bQizT0Wky9Jj1fvB2dVppwzatsk2E0iROHi4o9c9I",
+        oauth_signature="Ynt2AZo90b7S0QTr1pmN8G7O8v8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1467446702", oauth_token="468bdc9aefc84702b84934d969a14d9a",
+        oauth_version="1.0"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.0
+      Date:
+      - Fri, 02 Dec 2016 10:10:56 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '49'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Headers:
+      - X-Requested-With, Content-Type
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+    body:
+      encoding: UTF-8
+      string: "[{\"time\":1483225200000,\"values\":{\"energyOut\":214993344475050}},{\"time\":1483226100000,\"values\":{\"energyOut\":214994624115783}},{\"time\":1483227000000,\"values\":{\"energyOut\":214995974453320}},{\"time\":1483227900000,\"values\":{\"energyOut\":214997510097785}},{\"time\":1483228800000,\"values\":{\"energyOut\":214998856013839}}]"
+    http_version:
+  recorded_at: Sat, 02 Jul 2016 08:05:03 GMT
+- request:
+    method: get
+    uri: https://api.discovergy.com/public/v1/readings?each=false&fields=energyOut&from=1454281200000&meterId=EASYMETER_60139082&resolution=one_day&to=1456786800000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - OAuth gem v0.5.1
+      Authorization:
+      - OAuth oauth_consumer_key="e2m206tufotddbts9lj6g16apk", oauth_nonce="76bQizT0Wky9Jj1fvB2dVppwzatsk2E0iROHi4o9c9I",
+        oauth_signature="Ynt2AZo90b7S0QTr1pmN8G7O8v8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1467446702", oauth_token="468bdc9aefc84702b84934d969a14d9a",
+        oauth_version="1.0"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.0
+      Date:
+      - Fri, 02 Dec 2016 10:10:56 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '49'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Headers:
+      - X-Requested-With, Content-Type
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+    body:
+      encoding: UTF-8
+      string: "[{\"time\":1483225200000,\"values\":{\"energyOut\":214993344475050}},{\"time\":1483311600000,\"values\":{\"energyOut\":215166444127724}},{\"time\":1483398000000,\"values\":{\"energyOut\":215427562417742}}]"
+    http_version:
+  recorded_at: Sat, 02 Jul 2016 08:05:03 GMT
+- request:
+    method: get
+    uri: https://api.discovergy.com/public/v1/readings?each=false&fields=energyOut&from=1454281200000&meterId=EASYMETER_60139082&resolution=one_day&to=1456786800000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - OAuth gem v0.5.1
+      Authorization:
+      - OAuth oauth_consumer_key="e2m206tufotddbts9lj6g16apk", oauth_nonce="76bQizT0Wky9Jj1fvB2dVppwzatsk2E0iROHi4o9c9I",
+        oauth_signature="Ynt2AZo90b7S0QTr1pmN8G7O8v8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1467446702", oauth_token="468bdc9aefc84702b84934d969a14d9a",
+        oauth_version="1.0"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.0
+      Date:
+      - Fri, 02 Dec 2016 10:10:56 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '49'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Headers:
+      - X-Requested-With, Content-Type
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+    body:
+      encoding: UTF-8
+      string: "[{\"time\":1483225200000,\"values\":{\"energyOut\":214993344475050}},{\"time\":1483311600000,\"values\":{\"energyOut\":215166444127724}},{\"time\":1483398000000,\"values\":{\"energyOut\":215427562417742}}]"
+    http_version:
+  recorded_at: Sat, 02 Jul 2016 08:05:03 GMT
+- request:
+    method: get
+    uri: https://api.discovergy.com/public/v1/readings?each=false&fields=energy&from=1454281200000&meterId=EASYMETER_60139082&resolution=one_day&to=1456786800000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - OAuth gem v0.5.1
+      Authorization:
+      - OAuth oauth_consumer_key="e2m206tufotddbts9lj6g16apk", oauth_nonce="76bQizT0Wky9Jj1fvB2dVppwzatsk2E0iROHi4o9c9I",
+        oauth_signature="Ynt2AZo90b7S0QTr1pmN8G7O8v8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1467446702", oauth_token="468bdc9aefc84702b84934d969a14d9a",
+        oauth_version="1.0"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.0
+      Date:
+      - Fri, 02 Dec 2016 10:10:56 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '49'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Headers:
+      - X-Requested-With, Content-Type
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+    body:
+      encoding: UTF-8
+      string: "[{\"time\":1483225200000,\"values\":{\"energy\":214993344475050}},{\"time\":1483311600000,\"values\":{\"energy\":215166444127724}},{\"time\":1483398000000,\"values\":{\"energy\":215427562417742}}]"
+    http_version:
+  recorded_at: Sat, 02 Jul 2016 08:05:03 GMT
+- request:
+    method: get
+    uri: https://api.discovergy.com/public/v1/readings?each=false&fields=energy&from=1454281200000&meterId=EASYMETER_60139082&resolution=one_day&to=1456786800000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - OAuth gem v0.5.1
+      Authorization:
+      - OAuth oauth_consumer_key="e2m206tufotddbts9lj6g16apk", oauth_nonce="76bQizT0Wky9Jj1fvB2dVppwzatsk2E0iROHi4o9c9I",
+        oauth_signature="Ynt2AZo90b7S0QTr1pmN8G7O8v8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1467446702", oauth_token="468bdc9aefc84702b84934d969a14d9a",
+        oauth_version="1.0"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.0
+      Date:
+      - Fri, 02 Dec 2016 10:10:56 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '49'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Headers:
+      - X-Requested-With, Content-Type
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+    body:
+      encoding: UTF-8
+      string: "[{\"time\":1483225200000,\"values\":{\"energy\":214993344475050}},{\"time\":1483311600000,\"values\":{\"energy\":215166444127724}},{\"time\":1483398000000,\"values\":{\"energy\":215427562417742}}]"
+    http_version:
+  recorded_at: Sat, 02 Jul 2016 08:05:03 GMT
+- request:
+    method: get
+    uri: https://api.discovergy.com/public/v1/readings?each=false&fields=energy&from=1451602800000&meterId=EASYMETER_60139082&resolution=one_month&to=1483225200000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - OAuth gem v0.5.1
+      Authorization:
+      - OAuth oauth_consumer_key="e2m206tufotddbts9lj6g16apk", oauth_nonce="76bQizT0Wky9Jj1fvB2dVppwzatsk2E0iROHi4o9c9I",
+        oauth_signature="Ynt2AZo90b7S0QTr1pmN8G7O8v8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1467446702", oauth_token="468bdc9aefc84702b84934d969a14d9a",
+        oauth_version="1.0"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.0
+      Date:
+      - Fri, 02 Dec 2016 10:10:56 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '49'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Headers:
+      - X-Requested-With, Content-Type
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+    body:
+      encoding: UTF-8
+      string: "[{\"time\":1483225200000,\"values\":{\"energy\":140329081776272}},{\"time\":1483311600000,\"values\":{\"energy\":140540876196298}},{\"time\":1483398000000,\"values\":{\"energy\":140753205311527}}]"
+    http_version:
+  recorded_at: Sat, 02 Jul 2016 08:05:03 GMT
+- request:
+    method: get
+    uri: https://api.discovergy.com/public/v1/readings?each=false&fields=energyOut&from=1451602800000&meterId=EASYMETER_60139082&resolution=one_month&to=1483225200000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - OAuth gem v0.5.1
+      Authorization:
+      - OAuth oauth_consumer_key="e2m206tufotddbts9lj6g16apk", oauth_nonce="76bQizT0Wky9Jj1fvB2dVppwzatsk2E0iROHi4o9c9I",
+        oauth_signature="Ynt2AZo90b7S0QTr1pmN8G7O8v8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1467446702", oauth_token="468bdc9aefc84702b84934d969a14d9a",
+        oauth_version="1.0"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.0
+      Date:
+      - Fri, 02 Dec 2016 10:10:56 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '49'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Headers:
+      - X-Requested-With, Content-Type
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+    body:
+      encoding: UTF-8
+      string: "[{\"time\":1483225200000,\"values\":{\"energyOut\":140329081776272}},{\"time\":1483311600000,\"values\":{\"energyOut\":140540876196298}},{\"time\":1483398000000,\"values\":{\"energyOut\":140753205311527}}]"
+    http_version:
+  recorded_at: Sat, 02 Jul 2016 08:05:03 GMT
+- request:
+    method: get
+    uri: https://api.discovergy.com/public/v1/readings?each=false&fields=energyOut&from=1451602800000&meterId=EASYMETER_60139082&resolution=one_month&to=1483225200000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - OAuth gem v0.5.1
+      Authorization:
+      - OAuth oauth_consumer_key="e2m206tufotddbts9lj6g16apk", oauth_nonce="76bQizT0Wky9Jj1fvB2dVppwzatsk2E0iROHi4o9c9I",
+        oauth_signature="Ynt2AZo90b7S0QTr1pmN8G7O8v8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1467446702", oauth_token="468bdc9aefc84702b84934d969a14d9a",
+        oauth_version="1.0"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.0
+      Date:
+      - Fri, 02 Dec 2016 10:10:56 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '49'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Headers:
+      - X-Requested-With, Content-Type
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+    body:
+      encoding: UTF-8
+      string: "[{\"time\":1483225200000,\"values\":{\"energyOut\":140329081776272}},{\"time\":1483311600000,\"values\":{\"energyOut\":140540876196298}},{\"time\":1483398000000,\"values\":{\"energyOut\":140753205311527}}]"
+    http_version:
+  recorded_at: Sat, 02 Jul 2016 08:05:03 GMT
+- request:
+    method: get
+    uri: https://api.discovergy.com/public/v1/readings?each=false&fields=energy&from=1451602800000&meterId=EASYMETER_60139082&resolution=one_month&to=1483225200000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - OAuth gem v0.5.1
+      Authorization:
+      - OAuth oauth_consumer_key="e2m206tufotddbts9lj6g16apk", oauth_nonce="76bQizT0Wky9Jj1fvB2dVppwzatsk2E0iROHi4o9c9I",
+        oauth_signature="Ynt2AZo90b7S0QTr1pmN8G7O8v8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1467446702", oauth_token="468bdc9aefc84702b84934d969a14d9a",
+        oauth_version="1.0"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.0
+      Date:
+      - Fri, 02 Dec 2016 10:10:56 GMT
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '49'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Headers:
+      - X-Requested-With, Content-Type
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+    body:
+      encoding: UTF-8
+      string: "[{\"time\":1483225200000,\"values\":{\"energy\":140329081776272}},{\"time\":1483311600000,\"values\":{\"energy\":140540876196298}},{\"time\":1483398000000,\"values\":{\"energy\":140753205311527}}]"
+    http_version:
+  recorded_at: Sat, 02 Jul 2016 08:05:03 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
connects #586 

this implementation just wraps an http layer around the internal API, it encapsulates the decision which resolution is used for which duration inside the implementation of the various dataources:
year: monthly
month: daily
day: fifteenly
hours: raw, i.e. determined by the datasource implementation. discovergy 2 seconds, standard-profile 15 minutes

the client and the endpoint are unaware about the actual resolution and energy vs. power as it is decided by the datasource.

it also ensure parameter parsing happens only once, i.e. by the http framework in use, i.e. no combined attributes which needs to be splittet to get actual two attributes.

it follows the separation of concern pattern, the endpoint deals with the http related task, the backend implements the actual functionality. 

all our endpoints follow this idea unless we needed to keep backward compatible which is done in the old aggregate endpoints and the old forms endpoint (vs the new one under api/v1/contracts/) where the endpoint does some parameter acrobatic to map the old to new backend implementation of the API.

if create a new API endpoint like such backward compatible one, i.e. not exposing the backend API but trying make something more general and then test parameter whether their combination is allowed, then I need someone explaining me how to build libraries, APIs and a principle like separation of concern and inversion of control, reduction of redundancy, etc as I am not able to match them with the proposed implementation of #586 - and if I can not understand it I am at the wrong place working at the backend.