### PR TITLE
Pass host to Sequel migrations so they work in environments where

### DIFF
--- a/db/support/active_record_sequel_migrations_adapter.rb
+++ b/db/support/active_record_sequel_migrations_adapter.rb
@@ -3,7 +3,7 @@ module ActiveRecordSequelMigrationsAdapter
     config = ActiveRecord::Base.connection_config.dup
     # NOTE the PG_USER is for codeship
     config[:user] = config[:username] || ENV['PG_USER'] || ENV['USER']
-    config.slice(:user, :password, :port, :database)
+    config.slice(:host, :user, :password, :port, :database)
   end
 
   def run_sequel_migration(number)


### PR DESCRIPTION
DB is not available via a socket on localhost (staging, production).