### PR TITLE
Only use Raven to report exception when Raven is defined

### DIFF
--- a/lib/buzzn/roda/helpers/error_handler.rb
+++ b/lib/buzzn/roda/helpers/error_handler.rb
@@ -33,7 +33,9 @@ module Buzzn
             logger.error{ "#{e.message}\n\t" + e.backtrace.join("\n\t")}
             errors = "{\"errors\":[{\"detail\":\"internal server error\"}]}"
           end
-          Raven.capture_exception(e) if response.status == 500
+          if defined?(Raven) && response.status == 500
+            Raven.capture_exception(e)
+          end
           response.write(errors)
         end
       end


### PR DESCRIPTION
Raven is in the staging/production section of the Gemfile so we don't pollute the staging/prod exception reporting tools with dev or test exceptions. So we can't rely on Raven being loaded.
  