### PR TITLE
Prevent Discovergy password from being logged

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
     fabrication (2.15.2)
     factory_girl (4.8.1)
       activesupport (>= 3.0.0)
-    faraday (0.9.2)
+    faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
     ffaker (2.2.0)
     ffi (1.9.18)


### PR DESCRIPTION
Update the faraday gem to the latest version and use it's log filtering feature to prevent the password from being logged plain-text.