### PR TITLE
Rake task to wrap all the steps needed to update the heroku db

### DIFF
--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -3,7 +3,7 @@ namespace :heroku do
   def push_local_db_to_heroku(env)
     sh "heroku pg:reset --remote=#{env}"
     sh "heroku pg:push buzzn_development DATABASE_URL --remote=#{env}" do |ok, status|
-      puts "Note: warnings/errors about extension ownership can ignored." unless ok
+      puts "Note: warnings/errors about extension ownership can be ignored." unless ok
     end
   end
 


### PR DESCRIPTION
One-line rake tasks to perform all the steps needed to update the staging or production DB with the latest example and beekeeper data.
Created to prevent errors that happen when doing these steps one by one, by hand.