### PR TITLE
Update architecture docs

### DIFF
--- a/docs/application_architecture.md
+++ b/docs/application_architecture.md
@@ -59,13 +59,13 @@ Are deprecated, see the validations section on this page for how to do them inst
 
 ### What about Rails?
 
-The Rails framework does [a lot of useful things](https://github.com/rails-api/rails-api#handled-at-the-middleware-layer), but we don't use most of it at the time of writing:
+At the time of writing Rails is a legacy dependency and almost removed. Details:
 
-- the mid-term plan is to remove the Rails gem, the gems we still use will become direct dependencies in the Gemfile (like activerecord, activesupport, rack, rack-test, bundler, ...)
-- we don't use Rails controllers, they are replaced by the Roda tree.
-- ActiveRecord validations aren't used, see "How & where do we validate stuff?" for the replacement.
-- we don't use Rails views and the asset pipeline. Since the application is API-only, we render the JSON using the homemade `Buzzn::Resource::*` objects.
-- the Rails logging mechanism is replaced by `Buzzn::Logger`. 
+- currently Rails is only needed because we still have some gem dependencies to it, like rspec-rails, money-rails, dotenv-rails. The Rails dependencies we'll continue to use (activerecord, activesupport, rack, rack-test, bundler, ...) will then become direct dependencies
+- instead of Rails controllers, we use Roda tree procs.
+- instead of ActiveRecord validations, we use dry-schema; see "How & where do we validate stuff?" for details.
+- instead of the views and the asset pipeline, we use the homemade `Buzzn::Resource::*` objects to render the JSON (the application is API-only).
+- instead of the Rails logger, we use `Buzzn::Logger`. 
 - Rails environments are deprecated. The application should only be configured through environment variables. See http://12factor.net/config for the reasoning.
 - tests: the tests inherit from Rack::Test.
 - the `rails server` and `rails console` tasks have been replaced by `bin/server` and `bin/console`.


### PR DESCRIPTION
To remember how we use the different DRY schemas I revisited the architecture docs and updated them as well.